### PR TITLE
Add ESP Audio Codec and ESP Audio Effects to enhance performance

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -72,7 +72,7 @@ elseif(CONFIG_BOARD_TYPE_XMINI_C3)
 elseif(CONFIG_BOARD_TYPE_ESP32S3_KORVO2_V3)
     set(BOARD_TYPE "esp32s3-korvo2-v3")
 elseif(CONFIG_BOARD_TYPE_ESP_SPARKBOT)
-    set(BOARD_TYPE "esp-sparkbot")    
+    set(BOARD_TYPE "esp-sparkbot")
 elseif(CONFIG_BOARD_TYPE_ESP32S3_Touch_AMOLED_1_8)
     set(BOARD_TYPE "esp32-s3-touch-amoled-1.8")
 elseif(CONFIG_BOARD_TYPE_ESP32S3_Touch_LCD_1_85C)
@@ -114,6 +114,8 @@ endif()
 if(CONFIG_USE_AUDIO_PROCESSING)
     list(APPEND SOURCES "audio_processing/audio_processor.cc" "audio_processing/wake_word_detect.cc")
 endif()
+
+list(APPEND SOURCES "audio_processing/opus_decoder.cc" "audio_processing/opus_encoder.cc"  "audio_processing/opus_resampler.cc")
 
 # 如果目标芯片是 ESP32，则排除特定文件
 if(CONFIG_IDF_TARGET_ESP32)

--- a/main/audio_processing/opus_decoder.cc
+++ b/main/audio_processing/opus_decoder.cc
@@ -1,0 +1,64 @@
+#include "opus_decoder.h"
+#include <esp_log.h>
+#include "esp_audio_dec_default.h"
+
+#define TAG "OpusDecoderWrapper"
+
+
+OpusDecoderWrapper::OpusDecoderWrapper(int sample_rate, int channels, int duration_ms)
+{
+    int error = 0;
+    esp_opus_dec_register();
+    esp_opus_dec_cfg_t opus_cfg = {
+        .sample_rate = (uint32_t)sample_rate,
+        .channel = (uint8_t)channels,
+        .self_delimited = false,
+    };
+    esp_opus_dec_open(&opus_cfg, sizeof(esp_opus_dec_cfg_t), &audio_dec_);
+    if (audio_dec_ == nullptr) {
+        ESP_LOGE(TAG, "Failed to create audio decoder, error code: %d", error);
+        return;
+    }
+    frame_size_ = sample_rate / 1000 * channels * duration_ms;
+}
+
+OpusDecoderWrapper::~OpusDecoderWrapper()
+{
+    if (audio_dec_ != nullptr) {
+        esp_audio_dec_close(audio_dec_);
+    }
+}
+
+bool OpusDecoderWrapper::Decode(std::vector<uint8_t> &&opus, std::vector<int16_t> &pcm)
+{
+    if (audio_dec_ == nullptr) {
+        ESP_LOGE(TAG, "Audio decoder is not configured");
+        return false;
+    }
+    pcm.resize(frame_size_);
+
+    esp_audio_dec_info_t info = {0};
+    esp_audio_dec_in_raw_t in = {
+        .buffer = opus.data(),
+        .len = opus.size(),
+    };
+    esp_audio_dec_out_frame_t out = {
+        .buffer = (uint8_t*)pcm.data(),
+        .len = 2880,
+    };
+    int ret = esp_opus_dec_decode(audio_dec_, &in, &out, &info);
+    if (ret < 0) {
+        ESP_LOGE(TAG, "Failed to decode audio, error code: %d, OPUS sz:%d, PCM sz:%d, consumed:%ld, needed_size:%ld", ret, opus.size(), pcm.size(), in.consumed, out.needed_size);
+        return false;
+    }
+    pcm.resize(out.decoded_size/2);
+    ESP_LOGD(TAG, "Decode audio:%d, OPUS sz:%d, PCM sz:%d, consumed:%ld, needed_size:%ld", ret, opus.size(), pcm.size(), in.consumed, out.needed_size);
+
+    return true;
+}
+
+void OpusDecoderWrapper::ResetState()
+{
+    ESP_LOGD(TAG, "%s", __func__);
+}
+

--- a/main/audio_processing/opus_decoder.h
+++ b/main/audio_processing/opus_decoder.h
@@ -1,0 +1,23 @@
+#ifndef _OPUS_DECODER_WRAPPER_H_
+#define _OPUS_DECODER_WRAPPER_H_
+
+#include <functional>
+#include <vector>
+#include <cstdint>
+#include "esp_audio_dec.h"
+
+
+class OpusDecoderWrapper {
+public:
+    OpusDecoderWrapper(int sample_rate, int channels, int duration_ms = 60);
+    ~OpusDecoderWrapper();
+
+    bool Decode(std::vector<uint8_t>&& opus, std::vector<int16_t>& pcm);
+    void ResetState();
+
+private:
+    esp_audio_dec_handle_t audio_dec_ = nullptr;
+    int frame_size_;
+};
+
+#endif // _OPUS_DECODER_WRAPPER_H_

--- a/main/audio_processing/opus_encoder.cc
+++ b/main/audio_processing/opus_encoder.cc
@@ -1,0 +1,84 @@
+#include "opus_encoder.h"
+#include <esp_log.h>
+
+#define TAG "OpusEncoderWrapper"
+
+
+OpusEncoderWrapper::OpusEncoderWrapper(int sample_rate, int channels, int duration_ms) {
+    int error = 0;
+    esp_opus_enc_config_t opus_enc = ESP_OPUS_ENC_CONFIG_DEFAULT();
+    opus_enc.sample_rate = sample_rate;
+    opus_enc.channel = channels;
+    opus_enc.frame_duration = ESP_OPUS_ENC_FRAME_DURATION_60_MS;
+    opus_enc.complexity = 1;
+    opus_enc.bitrate = 20000;
+    opus_enc.enable_dtx = true;
+    opus_enc.enable_vbr = true;
+    esp_opus_enc_register();
+
+    esp_opus_enc_open(&opus_enc, sizeof(esp_opus_enc_config_t), &opus_enc_);
+    if (opus_enc_ == nullptr) {
+        ESP_LOGE(TAG, "Failed to create audio encoder, error code: %d", error);
+        return;
+    }
+    esp_opus_enc_get_frame_size(opus_enc_, &frame_size_, &out_byte_size_);
+    frame_size_ /= 2;
+}
+
+OpusEncoderWrapper::~OpusEncoderWrapper() {
+    if (opus_enc_ != nullptr) {
+        esp_opus_enc_close(opus_enc_);
+    }
+}
+
+void OpusEncoderWrapper::Encode(std::vector<int16_t>&& pcm, std::function<void(std::vector<uint8_t>&& opus)> handler) {
+    if (opus_enc_ == nullptr) {
+        ESP_LOGE(TAG, "Audio encoder is not configured");
+        return;
+    }
+
+    if (in_buffer_.empty()) {
+        in_buffer_ = std::move(pcm);
+    } else {
+        in_buffer_.insert(in_buffer_.end(), pcm.begin(), pcm.end());
+    }
+
+    while (in_buffer_.size() >= frame_size_) {
+        std::vector<uint8_t> opus(out_byte_size_);
+        esp_audio_enc_in_frame_t in ={
+            .buffer = (uint8_t*)in_buffer_.data(),
+            .len = (uint32_t)frame_size_*2,
+        };
+        esp_audio_enc_out_frame_t out ={
+            .buffer = opus.data(),
+            .len = opus.size(),
+            .encoded_bytes = 0,
+        };
+        auto ret = esp_opus_enc_process(opus_enc_, &in, &out);
+        if (ret < 0) {
+            ESP_LOGE(TAG, "Failed to encode audio, error code: %d, out.len:%ld", ret, out.len);
+            return;
+        }
+        opus.resize(out.encoded_bytes);
+        ESP_LOGD(TAG, "Encode audio, frame_size:%d, out_byte_size:%d", frame_size_, opus.size());
+        if (handler != nullptr) {
+            handler(std::move(opus));
+        }
+        in_buffer_.erase(in_buffer_.begin(), in_buffer_.begin() + frame_size_);
+    }
+}
+
+void OpusEncoderWrapper::ResetState() {
+    ESP_LOGD(TAG, "%s", __func__);
+    if (opus_enc_ != nullptr) {
+        in_buffer_.clear();
+    }
+}
+
+void OpusEncoderWrapper::SetDtx(bool enable) {
+    ESP_LOGD(TAG, "%s, enable:%d", __func__, enable);
+}
+
+void OpusEncoderWrapper::SetComplexity(int complexity) {
+    ESP_LOGD(TAG, "%s, complexity:%d", __func__, complexity);
+}

--- a/main/audio_processing/opus_encoder.h
+++ b/main/audio_processing/opus_encoder.h
@@ -1,0 +1,32 @@
+#ifndef _OPUS_ENCODER_WRAPPER_H_
+#define _OPUS_ENCODER_WRAPPER_H_
+
+#include <functional>
+#include <vector>
+#include <memory>
+#include <cstdint>
+
+#include "esp_opus_enc.h"
+
+#define MAX_OPUS_PACKET_SIZE 1500
+
+
+class OpusEncoderWrapper {
+public:
+    OpusEncoderWrapper(int sample_rate, int channels, int duration_ms = 60);
+    ~OpusEncoderWrapper();
+
+    void SetDtx(bool enable);
+    void SetComplexity(int complexity);
+    void Encode(std::vector<int16_t>&& pcm, std::function<void(std::vector<uint8_t>&& opus)> handler);
+    bool IsBufferEmpty() const { return in_buffer_.empty(); }
+    void ResetState();
+
+private:
+    esp_audio_enc_handle_t opus_enc_ = nullptr;
+    int frame_size_;
+    int out_byte_size_;
+    std::vector<int16_t> in_buffer_;
+};
+
+#endif // _OPUS_ENCODER_H_

--- a/main/audio_processing/opus_resampler.cc
+++ b/main/audio_processing/opus_resampler.cc
@@ -1,0 +1,43 @@
+#include "opus_resampler.h"
+#include "esp_log.h"
+
+#define TAG "OpusResampler"
+
+OpusResampler::OpusResampler() {
+}
+
+OpusResampler::~OpusResampler() {
+    esp_ae_rate_cvt_close(esp_rate_);
+}
+
+void OpusResampler::Configure(int input_sample_rate, int output_sample_rate) {
+    esp_ae_rate_cvt_cfg_t cfg = {
+        .src_rate = (uint32_t)input_sample_rate,
+        .dest_rate = (uint32_t)output_sample_rate,
+        .channel = 1,
+        .bits_per_sample = 16,
+        .complexity = 1,
+        .perf_type = ESP_AE_RATE_CVT_PERF_TYPE_SPEED,
+    };
+    auto ret = esp_ae_rate_cvt_open(&cfg, &esp_rate_);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "Failed to initialize resampler");
+        return;
+    }
+    input_sample_rate_ = input_sample_rate;
+    output_sample_rate_ = output_sample_rate;
+    ESP_LOGI(TAG, "Resampler configured with input sample rate %d and output sample rate %d", input_sample_rate_, output_sample_rate_);
+}
+
+void OpusResampler::Process(const int16_t *input, int input_samples, int16_t *output) {
+    uint32_t out_samples= 2880;
+    auto ret  = esp_ae_rate_cvt_process(esp_rate_, (void*)input, input_samples, output, &out_samples);
+    if (ret != 0) {
+        ESP_LOGE(TAG, "Failed to process resampler");
+    }
+}
+
+int OpusResampler::GetOutputSamples(int input_samples) const {
+    return input_samples * output_sample_rate_ / input_sample_rate_;
+}
+

--- a/main/audio_processing/opus_resampler.h
+++ b/main/audio_processing/opus_resampler.h
@@ -1,0 +1,27 @@
+#ifndef OPUS_RESAMPLER_H
+#define OPUS_RESAMPLER_H
+
+#include <cstdint>
+#include "esp_ae_rate_cvt.h"
+
+class OpusResampler {
+public:
+    OpusResampler();
+    ~OpusResampler();
+
+    void Configure(int input_sample_rate, int output_sample_rate);
+    void Process(const int16_t *input, int input_samples, int16_t *output);
+    int GetOutputSamples(int input_samples) const;
+
+    int input_sample_rate() const { return input_sample_rate_; }
+    int output_sample_rate() const { return output_sample_rate_; }
+
+private:
+     esp_ae_rate_cvt_handle_t esp_rate_;
+    int input_sample_rate_;
+    int output_sample_rate_;
+};
+
+#endif
+
+

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -13,6 +13,8 @@ dependencies:
   78/xiaozhi-fonts: "~1.3.2"
   espressif/led_strip: "^2.4.1"
   espressif/esp_codec_dev: "~1.3.2"
+  espressif/esp_audio_codec: "~2.2"
+  espressif/esp_audio_effects: "~1.0"
   espressif/esp-sr: "^1.9.0"
   espressif/button: "^3.3.1"
   lvgl/lvgl: "~9.2.2"


### PR DESCRIPTION
- Replacing the [ESP Audio Codec](https://components.espressif.com/components/espressif/esp_audio_codec/versions/2.0.3) and [ESP Audio Effects](https://components.espressif.com/components/espressif/esp_audio_effects/versions/1.0.1) modules
- Encoding and decoding reduce the task load by at least 10% on ESP32S3