### PR TITLE
fix:es8311 share i2s wake bug

### DIFF
--- a/main/audio_codecs/es8311_audio_codec.cc
+++ b/main/audio_codecs/es8311_audio_codec.cc
@@ -12,7 +12,7 @@ Es8311AudioCodec::Es8311AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port,
     input_channels_ = 1; // 输入通道数
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
-
+    pa_pin_ = pa_pin;
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
 
     // Do initialize of related interface: data_if, ctrl_if and gpio_if
@@ -57,7 +57,8 @@ Es8311AudioCodec::Es8311AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port,
     dev_cfg.dev_type = ESP_CODEC_DEV_TYPE_IN;
     input_dev_ = esp_codec_dev_new(&dev_cfg);
     assert(input_dev_ != NULL);
-
+    esp_codec_set_disable_when_closed(output_dev_, false);
+    esp_codec_set_disable_when_closed(input_dev_, false);
     ESP_LOGI(TAG, "Es8311AudioCodec initialized");
 }
 
@@ -165,8 +166,10 @@ void Es8311AudioCodec::EnableOutput(bool enable) {
         };
         ESP_ERROR_CHECK(esp_codec_dev_open(output_dev_, &fs));
         ESP_ERROR_CHECK(esp_codec_dev_set_out_vol(output_dev_, output_volume_));
+        gpio_set_level(pa_pin_, 1);
     } else {
         ESP_ERROR_CHECK(esp_codec_dev_close(output_dev_));
+        gpio_set_level(pa_pin_, 0);
     }
     AudioCodec::EnableOutput(enable);
 }

--- a/main/audio_codecs/es8311_audio_codec.h
+++ b/main/audio_codecs/es8311_audio_codec.h
@@ -4,6 +4,7 @@
 #include "audio_codec.h"
 
 #include <driver/i2c.h>
+#include <driver/gpio.h>
 #include <esp_codec_dev.h>
 #include <esp_codec_dev_defaults.h>
 
@@ -16,6 +17,7 @@ private:
 
     esp_codec_dev_handle_t output_dev_ = nullptr;
     esp_codec_dev_handle_t input_dev_ = nullptr;
+    gpio_num_t pa_pin_ = GPIO_NUM_NC;
 
     void CreateDuplexChannels(gpio_num_t mclk, gpio_num_t bclk, gpio_num_t ws, gpio_num_t dout, gpio_num_t din);
 


### PR DESCRIPTION
1、增加了对PA的控制
2、增加esp_codec_set_disable_when_closed控制
3、避免了关闭输出时输入被关闭，无法唤醒的问题