### PR TITLE
新增 ESP32 系列开发板 对 OLED-0.96 SSD1306 屏幕显示的支持

### DIFF
--- a/main/boards/bread-compact-esp32/config.h
+++ b/main/boards/bread-compact-esp32/config.h
@@ -32,5 +32,11 @@
 #define TOUCH_BUTTON_GPIO       GPIO_NUM_5
 #define BUILTIN_LED_GPIO        GPIO_NUM_2
 
+#define DISPLAY_SDA_PIN GPIO_NUM_4
+#define DISPLAY_SCL_PIN GPIO_NUM_15
+#define DISPLAY_WIDTH   128
+#define DISPLAY_HEIGHT  64
+#define DISPLAY_MIRROR_X true
+#define DISPLAY_MIRROR_Y true
 
 #endif // _BOARD_CONFIG_H_

--- a/main/boards/bread-compact-esp32/esp32_bread_board.cc
+++ b/main/boards/bread-compact-esp32/esp32_bread_board.cc
@@ -6,18 +6,38 @@
 #include "config.h"
 #include "iot/thing_manager.h"
 #include "led/single_led.h"
-
+#include "display/ssd1306_display.h"
 #include <wifi_station.h>
 #include <esp_log.h>
 #include <driver/i2c_master.h>
 
 #define TAG "ESP32-MarsbearSupport"
 
+LV_FONT_DECLARE(font_puhui_14_1);
+LV_FONT_DECLARE(font_awesome_14_1);
+
 
 class CompactWifiBoard : public WifiBoard {
 private:
     Button boot_button_;
     Button touch_button_;
+    i2c_master_bus_handle_t display_i2c_bus_;
+
+    void InitializeDisplayI2c() {
+        i2c_master_bus_config_t bus_config = {
+            .i2c_port = (i2c_port_t)0,
+            .sda_io_num = DISPLAY_SDA_PIN,
+            .scl_io_num = DISPLAY_SCL_PIN,
+            .clk_source = I2C_CLK_SRC_DEFAULT,
+            .glitch_ignore_cnt = 7,
+            .intr_priority = 0,
+            .trans_queue_depth = 0,
+            .flags = {
+                .enable_internal_pullup = 1,
+            },
+        };
+        ESP_ERROR_CHECK(i2c_new_master_bus(&bus_config, &display_i2c_bus_));
+    }
 
     void InitializeButtons() {
         
@@ -59,6 +79,7 @@ private:
 public:
     CompactWifiBoard() : boot_button_(BOOT_BUTTON_GPIO), touch_button_(TOUCH_BUTTON_GPIO)
     {
+        InitializeDisplayI2c();
         InitializeButtons();
         InitializeIot();
     }
@@ -73,6 +94,12 @@ public:
             AUDIO_I2S_GPIO_BCLK, AUDIO_I2S_GPIO_WS, AUDIO_I2S_GPIO_DOUT, AUDIO_I2S_GPIO_DIN);
 #endif
         return &audio_codec;
+    }
+
+    virtual Display* GetDisplay() override {
+        static Ssd1306Display display(display_i2c_bus_, DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y,
+                                    &font_puhui_14_1, &font_awesome_14_1);
+        return &display;
     }
 
 };


### PR DESCRIPTION
新增 ESP32 系列开发板 对 OLED-0.96 SSD1306 屏幕显示的支持
已自测验证OK
邀请数位网友验证OK
1. 支持 ESP32 系列开发板: DevKitC / NodeMcu-32S / GoouuuESP32 / ESP32 DoIt / ESP-32S
2. 注意: 非ESP32-C3 / 非ESP32-S3
