### PR TITLE
修复 AtomS3 屏幕 RGB 顺序

### DIFF
--- a/main/boards/atoms3-echo-base/atoms3_echo_base.cc
+++ b/main/boards/atoms3-echo-base/atoms3_echo_base.cc
@@ -167,7 +167,7 @@ private:
         };
         esp_lcd_panel_dev_config_t panel_config = {};
         panel_config.reset_gpio_num = GPIO_NUM_34; // Set to -1 if not use
-        panel_config.rgb_endian = LCD_RGB_ENDIAN_RGB;
+        panel_config.rgb_endian = LCD_RGB_ENDIAN_BGR;
         panel_config.bits_per_pixel = 16; // Implemented by LCD command `3Ah` (16/18)
         panel_config.vendor_config = &gc9107_vendor_config;
 


### PR DESCRIPTION
修复了之前 PR 提到的问题： https://github.com/78/xiaozhi-esp32/pull/154

![fix-rgb](https://github.com/user-attachments/assets/fc306217-2ba4-45d1-a523-2e80c3342c6f)
