### PR TITLE
外接唤醒模组的支持，可以有多种自定义唤醒词，进行唤醒小智，ESP32(非C3，非S3) 面包板上已支持

### DIFF
--- a/main/application.cc
+++ b/main/application.cc
@@ -701,35 +701,18 @@ void Application::Reboot() {
     esp_restart();
 }
 
-void Application::WakeWordInvoke(const std::string& wake_word)
-{
-    //外接唤醒模组的支持，好处是可以有多种自定义唤醒词，进行唤醒小智
-    //唤醒模组需要一个GPIO Pin，设置成输出模式+高电平
-    //对该Pin进行唤醒设置，1秒内的低电平脉冲，也就是小智的一个Click
-    //可以参考 ESP32 面包板中的 asr_button_ 按钮的功能函数调用
-    //本人测试采用ASR-ProV1.0版本的唤醒模组，测试内容包括：自定义唤醒词，唤醒词打断，唤醒词回应
-    //此代码兼容其他型号的唤醒模组，并没做限制模组型号，方便大家使用
-    //Modify By MarsBear
-
-    if (device_state_ == kDeviceStateIdle) 
-    {
+void Application::WakeWordInvoke(const std::string& wake_word) {
+    if (device_state_ == kDeviceStateIdle) {
         ToggleChatState();
-        Schedule([this, wake_word]() 
-        {
-            if (protocol_)
-            {
+        Schedule([this, wake_word]() {
+            if (protocol_) {
                 protocol_->SendWakeWordDetected(wake_word); 
             }
         }); 
-    } 
-    else if (device_state_ == kDeviceStateSpeaking) 
-    {
+    } else if (device_state_ == kDeviceStateSpeaking) {
         AbortSpeaking(kAbortReasonNone);
-    } 
-    else if (device_state_ == kDeviceStateListening) 
-    {   
-        if (protocol_)
-        {
+    } else if (device_state_ == kDeviceStateListening) {   
+        if (protocol_) {
             protocol_->CloseAudioChannel();
         }
     }

--- a/main/application.cc
+++ b/main/application.cc
@@ -700,3 +700,37 @@ void Application::Reboot() {
     ESP_LOGI(TAG, "Rebooting...");
     esp_restart();
 }
+
+void Application::WakeWordInvoke(const std::string& wake_word)
+{
+    //外接唤醒模组的支持，好处是可以有多种自定义唤醒词，进行唤醒小智
+    //唤醒模组需要一个GPIO Pin，设置成输出模式+高电平
+    //对该Pin进行唤醒设置，1秒内的低电平脉冲，也就是小智的一个Click
+    //可以参考 ESP32 面包板中的 asr_button_ 按钮的功能函数调用
+    //本人测试采用ASR-ProV1.0版本的唤醒模组，测试内容包括：自定义唤醒词，唤醒词打断，唤醒词回应
+    //此代码兼容其他型号的唤醒模组，并没做限制模组型号，方便大家使用
+    //Modify By MarsBear
+
+    if (device_state_ == kDeviceStateIdle) 
+    {
+        ToggleChatState();
+        Schedule([this, wake_word]() 
+        {
+            if (protocol_)
+            {
+                protocol_->SendWakeWordDetected(wake_word); 
+            }
+        }); 
+    } 
+    else if (device_state_ == kDeviceStateSpeaking) 
+    {
+        AbortSpeaking(kAbortReasonNone);
+    } 
+    else if (device_state_ == kDeviceStateListening) 
+    {   
+        if (protocol_)
+        {
+            protocol_->CloseAudioChannel();
+        }
+    }
+}

--- a/main/application.h
+++ b/main/application.h
@@ -63,6 +63,7 @@ public:
     void StopListening();
     void UpdateIotStates();
     void Reboot();
+    void WakeWordInvoke(const std::string& wake_word);
 
 private:
     Application();

--- a/main/boards/bread-compact-esp32/config.h
+++ b/main/boards/bread-compact-esp32/config.h
@@ -30,6 +30,7 @@
 
 #define BOOT_BUTTON_GPIO        GPIO_NUM_0
 #define TOUCH_BUTTON_GPIO       GPIO_NUM_5
+#define ASR_BUTTON_GPIO         GPIO_NUM_19
 #define BUILTIN_LED_GPIO        GPIO_NUM_2
 
 #define DISPLAY_SDA_PIN GPIO_NUM_4

--- a/main/boards/bread-compact-esp32/esp32_bread_board.cc
+++ b/main/boards/bread-compact-esp32/esp32_bread_board.cc
@@ -21,6 +21,8 @@ class CompactWifiBoard : public WifiBoard {
 private:
     Button boot_button_;
     Button touch_button_;
+    Button asr_button_;
+
     i2c_master_bus_handle_t display_i2c_bus_;
 
     void InitializeDisplayI2c() {
@@ -59,6 +61,12 @@ private:
             gpio_set_level(BUILTIN_LED_GPIO, 1);
             app.ToggleChatState();
         });
+
+        asr_button_.OnClick([this]() {
+            std::string wake_word="你好，小智。";
+            Application::GetInstance().WakeWordInvoke(wake_word);
+        });
+
         touch_button_.OnPressDown([this]() {
             gpio_set_level(BUILTIN_LED_GPIO, 1);
             Application::GetInstance().StartListening();
@@ -77,7 +85,7 @@ private:
     }
 
 public:
-    CompactWifiBoard() : boot_button_(BOOT_BUTTON_GPIO), touch_button_(TOUCH_BUTTON_GPIO)
+    CompactWifiBoard() : boot_button_(BOOT_BUTTON_GPIO), touch_button_(TOUCH_BUTTON_GPIO), asr_button_(ASR_BUTTON_GPIO)
     {
         InitializeDisplayI2c();
         InitializeButtons();

--- a/main/boards/bread-compact-esp32/esp32_bread_board.cc
+++ b/main/boards/bread-compact-esp32/esp32_bread_board.cc
@@ -63,7 +63,7 @@ private:
         });
 
         asr_button_.OnClick([this]() {
-            std::string wake_word="你好，小智。";
+            std::string wake_word="你好小智";
             Application::GetInstance().WakeWordInvoke(wake_word);
         });
 


### PR DESCRIPTION
外接唤醒模组的支持，好处是可以有多种自定义唤醒词，进行唤醒小智
ESP32(非C3，非S3) 面包板上已支持
本人测试采用ASR-ProV1.0版本的唤醒模组，测试内容包括：自定义唤醒词，唤醒词打断，唤醒词回应
邀请2位同型号群友测试通过，邀请1位型号是HLK-V20的群友测试通过。
此代码兼容其他型号的唤醒模组，并没做限制模组型号，方便大家使用。