### PR TITLE
修复麦克风PDM数据位宽读取bug，唤醒也能正常使用

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -12,7 +12,7 @@ choice
     default LANGUAGE_ZH_CN
     help
         Select device display language
-        
+
     config LANGUAGE_ZH_CN
         bool "Chinese"
     config LANGUAGE_EN_US
@@ -79,11 +79,11 @@ choice BOARD_TYPE
     config BOARD_TYPE_MAGICLICK_2P4
         bool "神奇按钮 Magiclick_2.4"
     config BOARD_TYPE_MAGICLICK_2P5
-        bool "神奇按钮 Magiclick_2.5"  
+        bool "神奇按钮 Magiclick_2.5"
     config BOARD_TYPE_MAGICLICK_C3
         bool "神奇按钮 Magiclick_C3"
     config BOARD_TYPE_MAGICLICK_C3_V2
-        bool "神奇按钮 Magiclick_C3_v2"  
+        bool "神奇按钮 Magiclick_C3_v2"
     config BOARD_TYPE_M5STACK_CORE_S3
         bool "M5Stack CoreS3"
     config BOARD_TYPE_ATOMS3_ECHO_BASE
@@ -97,7 +97,7 @@ choice BOARD_TYPE
     config BOARD_TYPE_ESP32S3_KORVO2_V3
         bool "ESP32S3_KORVO2_V3开发板"
     config BOARD_TYPE_ESP_SPARKBOT
-        bool "ESP-SparkBot开发板"    
+        bool "ESP-SparkBot开发板"
     config BOARD_TYPE_ESP32S3_Touch_AMOLED_1_8
         bool "Waveshare ESP32-S3-Touch-AMOLED-1.8"
     config BOARD_TYPE_ESP32S3_Touch_LCD_1_85C
@@ -113,13 +113,13 @@ choice BOARD_TYPE
     config BOARD_TYPE_LILYGO_T_CAMERAPLUS_S3
         bool "LILYGO T-CameraPlus-S3"
     config BOARD_TYPE_MOVECALL_MOJI_ESP32S3
-         bool "Movecall Moji 小智AI衍生版"  
+         bool "Movecall Moji 小智AI衍生版"
     config BOARD_TYPE_ATK_DNESP32S3
         bool "正点原子DNESP32S3开发板"
     config BOARD_TYPE_ATK_DNESP32S3_BOX
         bool "正点原子DNESP32S3-BOX"
     config BOARD_TYPE_DU_CHATX
-        bool "嘟嘟开发板CHATX(wifi)"       
+        bool "嘟嘟开发板CHATX(wifi)"
     config BOARD_TYPE_ESP32S3_Taiji_Pi
         bool "太极小派esp32s3"
     config BOARD_TYPE_XINGZHI_Cube_0_96OLED_WIFI
@@ -155,33 +155,33 @@ choice DISPLAY_LCD_TYPE
     config LCD_ST7789_240X320
         bool "ST7789, 分辨率240*320, IPS"
     config LCD_ST7789_240X320_NO_IPS
-        bool "ST7789, 分辨率240*320, 非IPS"    
+        bool "ST7789, 分辨率240*320, 非IPS"
     config LCD_ST7789_170X320
-        bool "ST7789, 分辨率170*320"    
+        bool "ST7789, 分辨率170*320"
     config LCD_ST7789_172X320
-        bool "ST7789, 分辨率172*320"       
+        bool "ST7789, 分辨率172*320"
     config LCD_ST7789_240X280
-        bool "ST7789, 分辨率240*280"   
+        bool "ST7789, 分辨率240*280"
     config LCD_ST7789_240X240
-        bool "ST7789, 分辨率240*240"         
+        bool "ST7789, 分辨率240*240"
     config LCD_ST7789_240X240_7PIN
-        bool "ST7789, 分辨率240*240, 7PIN"       
+        bool "ST7789, 分辨率240*240, 7PIN"
     config LCD_ST7789_240X135
         bool "ST7789, 分辨率240*135"
     config LCD_ST7735_128X160
         bool "ST7735, 分辨率128*160"
     config LCD_ST7735_128X128
-        bool "ST7735, 分辨率128*128"    
+        bool "ST7735, 分辨率128*128"
     config LCD_ST7796_320X480
-        bool "ST7796, 分辨率320*480"    
+        bool "ST7796, 分辨率320*480"
     config LCD_ILI9341_240X320
         bool "ILI9341, 分辨率240*320"
     config LCD_ILI9341_240X320_NO_IPS
-        bool "ILI9341, 分辨率240*320, 非IPS"    
+        bool "ILI9341, 分辨率240*320, 非IPS"
     config LCD_GC9A01_240X240
-        bool "GC9A01, 分辨率240*240, 圆屏"            
+        bool "GC9A01, 分辨率240*240, 圆屏"
     config LCD_CUSTOM
-        bool "自定义屏幕参数"  
+        bool "自定义屏幕参数"
 endchoice
 
 config USE_AUDIO_PROCESSOR
@@ -198,4 +198,14 @@ config USE_WAKE_WORD_DETECT
     help
         需要 ESP32 S3 与 AFE 支持
 
+choice I2S_RECORD_MODE
+    prompt "I2S 录音通信模式"
+    default I2S_RECORD_MODE_DEFAULT
+    help
+        I2S 录音通信模式
+    config I2S_RECORD_MODE_DEFAULT
+        bool "默认"
+    config I2S_RECORD_MODE_PDM
+        bool "PDM"
+endchoice
 endmenu

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -197,15 +197,4 @@ config USE_WAKE_WORD_DETECT
     depends on IDF_TARGET_ESP32S3 && USE_AFE
     help
         需要 ESP32 S3 与 AFE 支持
-
-choice I2S_RECORD_MODE
-    prompt "I2S 录音通信模式"
-    default I2S_RECORD_MODE_DEFAULT
-    help
-        I2S 录音通信模式
-    config I2S_RECORD_MODE_DEFAULT
-        bool "默认"
-    config I2S_RECORD_MODE_PDM
-        bool "PDM"
-endchoice
 endmenu

--- a/main/audio_codecs/no_audio_codec.cc
+++ b/main/audio_codecs/no_audio_codec.cc
@@ -357,7 +357,6 @@ int NoAudioCodec::Write(const int16_t* data, int samples) {
     return bytes_written / sizeof(int32_t);
 }
 
-#ifndef CONFIG_I2S_RECORD_MODE_PDM
 int NoAudioCodec::Read(int16_t* dest, int samples) {
     size_t bytes_read;
 
@@ -374,8 +373,8 @@ int NoAudioCodec::Read(int16_t* dest, int samples) {
     }
     return samples;
 }
-#else
-int NoAudioCodec::Read(int16_t* dest, int samples) {
+
+int NoAudioCodecSimplexPdm::Read(int16_t* dest, int samples) {
     size_t bytes_read;
 
     // PDM 解调后的数据位宽为 16 位
@@ -393,4 +392,3 @@ int NoAudioCodec::Read(int16_t* dest, int samples) {
 
     return samples;
 }
-#endif

--- a/main/audio_codecs/no_audio_codec.cc
+++ b/main/audio_codecs/no_audio_codec.cc
@@ -2,6 +2,7 @@
 
 #include <esp_log.h>
 #include <cmath>
+#include <cstring>
 
 #define TAG "NoAudioCodec"
 
@@ -35,7 +36,7 @@ NoAudioCodecDuplex::NoAudioCodecDuplex(int input_sample_rate, int output_sample_
             .sample_rate_hz = (uint32_t)output_sample_rate_,
             .clk_src = I2S_CLK_SRC_DEFAULT,
             .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-			#ifdef   I2S_HW_VERSION_2    
+			#ifdef   I2S_HW_VERSION_2
 				.ext_clk_freq_hz = 0,
 			#endif
 
@@ -48,7 +49,7 @@ NoAudioCodecDuplex::NoAudioCodecDuplex(int input_sample_rate, int output_sample_
             .ws_width = I2S_DATA_BIT_WIDTH_32BIT,
             .ws_pol = false,
             .bit_shift = true,
-            #ifdef   I2S_HW_VERSION_2   
+            #ifdef   I2S_HW_VERSION_2
                 .left_align = true,
                 .big_endian = false,
                 .bit_order_lsb = false
@@ -94,7 +95,7 @@ ATK_NoAudioCodecDuplex::ATK_NoAudioCodecDuplex(int input_sample_rate, int output
             .sample_rate_hz = (uint32_t)output_sample_rate_,
             .clk_src = I2S_CLK_SRC_DEFAULT,
             .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-			#ifdef   I2S_HW_VERSION_2    
+			#ifdef   I2S_HW_VERSION_2
 				.ext_clk_freq_hz = 0,
 			#endif
         },
@@ -106,7 +107,7 @@ ATK_NoAudioCodecDuplex::ATK_NoAudioCodecDuplex(int input_sample_rate, int output
             .ws_width = I2S_DATA_BIT_WIDTH_16BIT,
             .ws_pol = false,
             .bit_shift = true,
-            #ifdef   I2S_HW_VERSION_2   
+            #ifdef   I2S_HW_VERSION_2
                 .left_align = true,
                 .big_endian = false,
                 .bit_order_lsb = false
@@ -153,7 +154,7 @@ NoAudioCodecSimplex::NoAudioCodecSimplex(int input_sample_rate, int output_sampl
             .sample_rate_hz = (uint32_t)output_sample_rate_,
             .clk_src = I2S_CLK_SRC_DEFAULT,
             .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-			#ifdef   I2S_HW_VERSION_2    
+			#ifdef   I2S_HW_VERSION_2
 				.ext_clk_freq_hz = 0,
 			#endif
 
@@ -166,7 +167,7 @@ NoAudioCodecSimplex::NoAudioCodecSimplex(int input_sample_rate, int output_sampl
             .ws_width = I2S_DATA_BIT_WIDTH_32BIT,
             .ws_pol = false,
             .bit_shift = true,
-            #ifdef   I2S_HW_VERSION_2   
+            #ifdef   I2S_HW_VERSION_2
                 .left_align = true,
                 .big_endian = false,
                 .bit_order_lsb = false
@@ -222,7 +223,7 @@ NoAudioCodecSimplex::NoAudioCodecSimplex(int input_sample_rate, int output_sampl
             .sample_rate_hz = (uint32_t)output_sample_rate_,
             .clk_src = I2S_CLK_SRC_DEFAULT,
             .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-			#ifdef   I2S_HW_VERSION_2    
+			#ifdef   I2S_HW_VERSION_2
 				.ext_clk_freq_hz = 0,
 			#endif
 
@@ -235,7 +236,7 @@ NoAudioCodecSimplex::NoAudioCodecSimplex(int input_sample_rate, int output_sampl
             .ws_width = I2S_DATA_BIT_WIDTH_32BIT,
             .ws_pol = false,
             .bit_shift = true,
-            #ifdef   I2S_HW_VERSION_2   
+            #ifdef   I2S_HW_VERSION_2
                 .left_align = true,
                 .big_endian = false,
                 .bit_order_lsb = false
@@ -290,7 +291,7 @@ NoAudioCodecSimplexPdm::NoAudioCodecSimplexPdm(int input_sample_rate, int output
             .sample_rate_hz = (uint32_t)output_sample_rate_,
             .clk_src = I2S_CLK_SRC_DEFAULT,
             .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-			#ifdef   I2S_HW_VERSION_2    
+			#ifdef   I2S_HW_VERSION_2
 				.ext_clk_freq_hz = 0,
 			#endif
 
@@ -321,7 +322,7 @@ NoAudioCodecSimplexPdm::NoAudioCodecSimplexPdm(int input_sample_rate, int output
         .gpio_cfg = {
             .clk = mic_sck,
             .din = mic_din,
- 
+
             .invert_flags = {
                 .clk_inv = false,
             },
@@ -356,6 +357,7 @@ int NoAudioCodec::Write(const int16_t* data, int samples) {
     return bytes_written / sizeof(int32_t);
 }
 
+#ifndef CONFIG_I2S_RECORD_MODE_PDM
 int NoAudioCodec::Read(int16_t* dest, int samples) {
     size_t bytes_read;
 
@@ -372,3 +374,23 @@ int NoAudioCodec::Read(int16_t* dest, int samples) {
     }
     return samples;
 }
+#else
+int NoAudioCodec::Read(int16_t* dest, int samples) {
+    size_t bytes_read;
+
+    // PDM 解调后的数据位宽为 16 位
+    std::vector<int16_t> bit16_buffer(samples);
+    if (i2s_channel_read(rx_handle_, bit16_buffer.data(), samples * sizeof(int16_t), &bytes_read, portMAX_DELAY) != ESP_OK) {
+        ESP_LOGE(TAG, "Read Failed!");
+        return 0;
+    }
+
+    // 计算实际读取的样本数
+    samples = bytes_read / sizeof(int16_t);
+
+    // 将 16 位数据直接复制到目标缓冲区
+    memcpy(dest, bit16_buffer.data(), samples * sizeof(int16_t));
+
+    return samples;
+}
+#endif

--- a/main/audio_codecs/no_audio_codec.h
+++ b/main/audio_codecs/no_audio_codec.h
@@ -34,6 +34,7 @@ public:
 class NoAudioCodecSimplexPdm : public NoAudioCodec {
 public:
     NoAudioCodecSimplexPdm(int input_sample_rate, int output_sample_rate, gpio_num_t spk_bclk, gpio_num_t spk_ws, gpio_num_t spk_dout, gpio_num_t mic_sck,  gpio_num_t mic_din);
+    int Read(int16_t* dest, int samples);
 };
 
 #endif // _NO_AUDIO_CODEC_H


### PR DESCRIPTION
在原有的no_audio_codec中，使用了通用的NoAudioCodec::Read()，但是并不适用于I2S的PDM通信模式，导致录音数据采样率异常(从小智后台播放历史对话声音可以得知)，因此唤醒词无法正常使用，且声纹识别也无法正确匹配。

根据乐鑫官方文档：[API 参考](https://docs.espressif.com/projects/esp-idf/zh_CN/stable/esp32s3/api-reference/index.html) » [外设 API](https://docs.espressif.com/projects/esp-idf/zh_CN/stable/esp32s3/api-reference/peripherals/index.html) » [I2S](https://docs.espressif.com/projects/esp-idf/zh_CN/stable/esp32s3/api-reference/peripherals/i2s.html)
> PDM RX 只在 I2S0 中受支持，且只支持 16 位宽的采样数据。

因此添加配置项，当麦克风使用PDM时，需要针对性的读取处理。

