### PR TITLE
feat:解决第一次编译，报错，找不到release路径的问题

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -36,7 +36,7 @@ def zip_bin(board_type, project_version):
     output_path = f"releases/v{project_version}_{board_type}.zip"
     if os.path.exists(output_path):
         os.remove(output_path)
-    with zipfile.ZipFile(output_path, 'w',compression=zipfile.ZIP_DEFLATED) as zipf:
+    with zipfile.ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.write("build/merged-binary.bin", arcname="merged-binary.bin")
     print(f"zip bin to {output_path} done")
     

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -31,10 +31,12 @@ def merge_bin():
         sys.exit(1)
 
 def zip_bin(board_type, project_version):
+    if not os.path.exists("releases"):
+        os.makedirs("releases")
     output_path = f"releases/v{project_version}_{board_type}.zip"
     if os.path.exists(output_path):
         os.remove(output_path)
-    with zipfile.ZipFile(output_path, 'w') as zipf:
+    with zipfile.ZipFile(output_path, 'w',compression=zipfile.ZIP_DEFLATED) as zipf:
         zipf.write("build/merged-binary.bin", arcname="merged-binary.bin")
     print(f"zip bin to {output_path} done")
     


### PR DESCRIPTION
1.解决第一次源码编译，由于本地不存在`release`文件夹,导致的zipfile报错问题：  
```  
board type: bread-compact-wifi
project version: 1.4.7
Traceback (most recent call last):
  File "E:\xiaozhiAI\soureCode\xiaozhi-esp32\scripts\release.py", line 133, in <module>
    release_current()
  File "E:\xiaozhiAI\soureCode\xiaozhi-esp32\scripts\release.py", line 48, in release_current
    zip_bin(board_type, project_version)
  File "E:\xiaozhiAI\soureCode\xiaozhi-esp32\scripts\release.py", line 37, in zip_bin
    with zipfile.ZipFile(output_path, 'w') as zipf:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "zipfile.py", line 1281, in __init__
FileNotFoundError: [Errno 2] No such file or directory: 'releases/v1.4.7_bread-compact-wifi.zip'
```
2. 增加`compression`参数，使用默认的压缩级别（默认为6），避免压缩包太大问题，使用后压缩包体积和调用系统`zip`指令生成的压缩包体积相当。