### PR TITLE
fix ESP32 IOT Pin Bug, Pin35 are used for input and cannot be used fo…

### DIFF
--- a/main/iot/things/lamp.cc
+++ b/main/iot/things/lamp.cc
@@ -13,7 +13,7 @@ namespace iot {
 class Lamp : public Thing {
 private:
 #ifdef CONFIG_IDF_TARGET_ESP32
-    gpio_num_t gpio_num_ = GPIO_NUM_35;
+    gpio_num_t gpio_num_ = GPIO_NUM_12;
 #else
     gpio_num_t gpio_num_ = GPIO_NUM_18;
 #endif


### PR DESCRIPTION
35引脚用于输入获取数据，无法用于输出引脚，导致初始化GPIO失败，已变更成12引脚


已同步文档：
![image](https://github.com/user-attachments/assets/8f2b7a66-06af-4fca-8260-227eb346ac3d)
