### PR TITLE
调整鱼鹰3.13开发板：1、降低pclk频率 2、增大背光PWM频率防止电感啸叫

### DIFF
--- a/main/boards/common/backlight.cc
+++ b/main/boards/common/backlight.cc
@@ -78,7 +78,7 @@ PwmBacklight::PwmBacklight(gpio_num_t pin, bool output_invert) : Backlight() {
         .speed_mode = LEDC_LOW_SPEED_MODE,
         .duty_resolution = LEDC_TIMER_10_BIT,
         .timer_num = LEDC_TIMER_0,
-        .freq_hz = 20000, //背光pwm频率需要高一点，防止电感啸叫
+        .freq_hz = 25000, //背光pwm频率需要高一点，防止电感啸叫
         .clk_cfg = LEDC_AUTO_CLK,
         .deconfigure = false
     };

--- a/main/boards/kevin-yuying-313lcd/esp_lcd_gc9503.h
+++ b/main/boards/kevin-yuying-313lcd/esp_lcd_gc9503.h
@@ -122,7 +122,7 @@ esp_err_t esp_lcd_new_panel_gc9503(const esp_lcd_panel_io_handle_t io, const esp
  */
 #define GC9503_376_960_PANEL_60HZ_RGB_TIMING()      \
     {                                               \
-        .pclk_hz = 20 * 1000 * 1000,                \
+        .pclk_hz = 16 * 1000 * 1000,                \
         .h_res = 376,                               \
         .v_res = 960,                               \
         .hsync_pulse_width = 8,                     \


### PR DESCRIPTION
1、降低pclk频率，OTA后发现会有屏幕偏移 
2、再次增大背光PWM频率防止电感啸叫