### PR TITLE
fix: 修复微信ui在消息数量超过上限后，气泡位置向上偏移的问题

### DIFF
--- a/main/display/lcd_display.cc
+++ b/main/display/lcd_display.cc
@@ -530,6 +530,9 @@ void LcdDisplay::SetChatMessage(const char* role, const char* content) {
         if (oldest_msg != nullptr) {
             lv_obj_del(oldest_msg);
             msg_count--;
+            // 删除最早的消息会导致所有气泡整体往上移
+            // 所以需要重新滚动到当前消息气泡位置
+            lv_obj_scroll_to_view_recursive(msg_bubble, LV_ANIM_ON);
         }else{
             break;
         }


### PR DESCRIPTION
微信ui在消息数量超过上限后，会删除最早的消息
删除最早的消息会导致所有气泡整体往上移
所以需要重新滚动到当前消息气泡位置
![Screenshot_20250327_150925](https://github.com/user-attachments/assets/8e8978cf-2183-4b96-b483-215dc993ad39)