### PR TITLE
Fix Sh1106 Compile Error Bug. IDF 5.3.2 Not supporting sh1106-esp-idf.

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -20,7 +20,10 @@ dependencies:
   lvgl/lvgl: "~9.2.2"
   esp_lvgl_port: "~2.4.4"
   espressif/esp_io_expander_tca95xx_16bit: "^2.0.0"
-  tny-robotics/sh1106-esp-idf: ^1.0.0
+  tny-robotics/sh1106-esp-idf:
+    version: "^1.0.0"
+    rules:
+      - if: 'idf_version >= "5.4.0"'
   ## Required IDF version
   idf:
     version: ">=5.3"


### PR DESCRIPTION
Fix Sh1106 Compile Error Bug. 
IDF 5.3.2 Not supporting sh1106-esp-idf.