### PR TITLE
Fix ESP32 Board Led No Light Bug

### DIFF
--- a/main/boards/bread-compact-esp32-lcd/esp32_bread_board_lcd.cc
+++ b/main/boards/bread-compact-esp32-lcd/esp32_bread_board_lcd.cc
@@ -195,11 +195,6 @@ public:
         
     }
 
-    virtual Led* GetLed() override {
-        static SingleLed led(BUILTIN_LED_GPIO);
-        return &led;
-    }
-
     virtual AudioCodec* GetAudioCodec() override {
 #ifdef AUDIO_I2S_METHOD_SIMPLEX
         static NoAudioCodecSimplex audio_codec(AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,


### PR DESCRIPTION
Fix ESP32 Board Led No Light Bug
Dev Board  GPIO2 LED  No Light ，Because GetLed has been implemented