### PR TITLE
修复 bug

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -51,7 +51,7 @@ def release_current():
 
 def get_all_board_types():
     board_configs = {}
-    with open("main/CMakeLists.txt") as f:
+    with open("main/CMakeLists.txt", encoding='utf-8') as f:
         lines = f.readlines()
         for i, line in enumerate(lines):
             # 查找 if(CONFIG_BOARD_TYPE_*) 行


### PR DESCRIPTION
在Windows上运行
python scripts/release.py [板子名称]
命令时，由于没有指定编码且Windows默认为GBK编码导致报错
UnicodeDecodeError: 'gbk' codec can't decode byte 0xac in position 963: illegal multibyte sequence
手动指定了utf-8编码