### PR TITLE
修复正点原子开发板XL9555驱动 Port1 无法正确输出的问题

### DIFF
--- a/main/boards/atk-dnesp32s3-box/atk_dnesp32s3_box.cc
+++ b/main/boards/atk-dnesp32s3-box/atk_dnesp32s3_box.cc
@@ -39,14 +39,16 @@ public:
 
     void SetOutputState(uint8_t bit, uint8_t level) {
         uint16_t data;
+        int index = bit;
+
         if (bit < 8) {
             data = ReadReg(0x02);
         } else {
             data = ReadReg(0x03);
-            bit -= 8;
+            index -= 8;
         }
 
-        data = (data & ~(1 << bit)) | (level << bit);
+        data = (data & ~(1 << index)) | (level << index);
 
         if (bit < 8) {
             WriteReg(0x02, data);

--- a/main/boards/atk-dnesp32s3/atk_dnesp32s3.cc
+++ b/main/boards/atk-dnesp32s3/atk_dnesp32s3.cc
@@ -28,14 +28,16 @@ public:
 
     void SetOutputState(uint8_t bit, uint8_t level) {
         uint16_t data;
+        int index = bit;
+
         if (bit < 8) {
             data = ReadReg(0x02);
         } else {
             data = ReadReg(0x03);
-            bit -= 8;
+            index -= 8;
         }
 
-        data = (data & ~(1 << bit)) | (level << bit);
+        data = (data & ~(1 << index)) | (level << index);
 
         if (bit < 8) {
             WriteReg(0x02, data);


### PR DESCRIPTION
修复正点原子开发板XL9555驱动 Port1 无法正确输出的问题