### PR TITLE
OTA checkversion增加了一些log, 便于三方开发调试自己的OTA接口

### DIFF
--- a/main/ota.cc
+++ b/main/ota.cc
@@ -107,6 +107,8 @@ bool Ota::CheckVersion() {
         return false;
     }
 
+    ESP_LOGI(TAG, "OTA request success: %s", check_version_url_.c_str());
+
     has_activation_code_ = false;
     has_activation_challenge_ = false;
     cJSON *activation = cJSON_GetObjectItem(root, "activation");
@@ -129,6 +131,8 @@ bool Ota::CheckVersion() {
         if (timeout_ms != NULL) {
             activation_timeout_ms_ = timeout_ms->valueint;
         }
+    } else {
+        ESP_LOGW(TAG, "No activation code found !");
     }
 
     has_mqtt_config_ = false;
@@ -144,6 +148,8 @@ bool Ota::CheckVersion() {
             }
         }
         has_mqtt_config_ = true;
+    } else {
+        ESP_LOGW(TAG, "No mqtt section found !");
     }
 
     has_websocket_config_ = false;
@@ -159,6 +165,8 @@ bool Ota::CheckVersion() {
             }
         }
         has_websocket_config_ = true;
+    } else {
+        ESP_LOGW(TAG, "No websocket section found!");
     }
 
     has_server_time_ = false;
@@ -182,6 +190,8 @@ bool Ota::CheckVersion() {
             settimeofday(&tv, NULL);
             has_server_time_ = true;
         }
+    } else {
+        ESP_LOGW(TAG, "No server_time section found!");
     }
 
     has_new_version_ = false;
@@ -210,7 +220,10 @@ bool Ota::CheckVersion() {
                 has_new_version_ = true;
             }
         }
+    } else {
+        ESP_LOGW(TAG, "No firmware section found!");
     }
+
     cJSON_Delete(root);
     return true;
 }


### PR DESCRIPTION
开发三方的Server时, 对OTA相关的部分必须针对性阅读 esp32的解析逻辑.  
- 为了给用户快速提供错误信息, 增加了一些调试log输出. 便于排查问题.