### PR TITLE
解决部分esp32-s3-touch-lcd-3.5开机黑屏不显示的问题

### DIFF
--- a/main/boards/esp32-s3-touch-lcd-3.5/esp32-s3-touch-lcd-3.5.cc
+++ b/main/boards/esp32-s3-touch-lcd-3.5/esp32-s3-touch-lcd-3.5.cc
@@ -251,6 +251,11 @@ public:
         InitializeAxp2101();
         InitializeSpi();
         InitializeLcdDisplay();
+        if (esp_reset_reason() == ESP_RST_POWERON)
+        {
+            fflush(stdout);
+            esp_restart();
+        }
         InitializeButtons();
         InitializeIot();
         GetBacklight()->RestoreBrightness();

--- a/main/boards/esp32-s3-touch-lcd-3.5/esp32-s3-touch-lcd-3.5.cc
+++ b/main/boards/esp32-s3-touch-lcd-3.5/esp32-s3-touch-lcd-3.5.cc
@@ -251,8 +251,8 @@ public:
         InitializeAxp2101();
         InitializeSpi();
         InitializeLcdDisplay();
-        if (esp_reset_reason() == ESP_RST_POWERON)
-        {
+        // 解决部分开机黑屏的问题
+        if (esp_reset_reason() == ESP_RST_POWERON) {
             fflush(stdout);
             esp_restart();
         }


### PR DESCRIPTION
部分esp32-s3-touch-lcd-3.5开机黑屏不显示，在初始化lcd后对ESP32进行软复位后才能解决这个问题，麻烦帮忙审阅一下。