### PR TITLE
Adjust dependency components for ESP32-P4

### DIFF
--- a/main/display/lcd_display.cc
+++ b/main/display/lcd_display.cc
@@ -435,8 +435,11 @@ void LcdDisplay::SetupUI() {
     lv_obj_center(low_battery_label_);
     lv_obj_add_flag(low_battery_popup_, LV_OBJ_FLAG_HIDDEN);
 }
-
+#if CONFIG_IDF_TARGET_ESP32P4
+#define  MAX_MESSAGES 40
+#else
 #define  MAX_MESSAGES 20
+#endif
 void LcdDisplay::SetChatMessage(const char* role, const char* content) {
     DisplayLockGuard lock(this);
     if (content_ == nullptr) {

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -19,6 +19,7 @@ dependencies:
   espressif/button: "~4.1.3"
   espressif/knob: "^1.0.0"
   espressif/esp_lcd_touch_ft5x06: "~1.0.7"
+  espressif/esp_lcd_touch_gt911: "^1"
   lvgl/lvgl: "~9.2.2"
   esp_lvgl_port: "~2.6.0"
   espressif/esp_io_expander_tca95xx_16bit: "^2.0.0"

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -26,6 +26,15 @@ dependencies:
     version: "^1.0.0"
     rules:
       - if: 'idf_version >= "5.4.0"'
+
+  waveshare/esp_lcd_jd9365_10_1:
+    version: "*"
+    rules:
+      - if: "target in [esp32p4]"
+  espressif/esp_wifi_remote:
+    version: "*"
+    rules:
+      - if: "target in [esp32p4]"
   ## Required IDF version
   idf:
     version: ">=5.3"


### PR DESCRIPTION
Last Pr https://github.com/78/xiaozhi-esp32/pull/589 I cancelled the component requirement in the yml file, which was wrong. So I re-opened the PR, now the dependency package is complete, you can normally select ESP32-P4 target compilation