### PR TITLE
正点原子DNESP32S3开发板新增相机（ov2640）

### DIFF
--- a/main/boards/atk-dnesp32s3/atk_dnesp32s3.cc
+++ b/main/boards/atk-dnesp32s3/atk_dnesp32s3.cc
@@ -163,38 +163,49 @@ private:
 
         camera_config_t config = {};
 
-        config.pin_pwdn = CAM_PIN_PWDN,  // 实际由 XL9555 控制
-        config.pin_reset = CAM_PIN_RESET,// 实际由 XL9555 控制
-        config.pin_xclk = CAM_PIN_XCLK,
-        config.pin_sccb_sda = CAM_PIN_SIOD,
-        config.pin_sccb_scl = CAM_PIN_SIOC,
+        config.pin_pwdn = CAM_PIN_PWDN;  // 实际由 XL9555 控制
+        config.pin_reset = CAM_PIN_RESET;// 实际由 XL9555 控制
+        config.pin_xclk = CAM_PIN_XCLK;
+        config.pin_sccb_sda = CAM_PIN_SIOD;
+        config.pin_sccb_scl = CAM_PIN_SIOC;
 
-        config.pin_d7 = CAM_PIN_D7,
-        config.pin_d6 = CAM_PIN_D6,
-        config.pin_d5 = CAM_PIN_D5,
-        config.pin_d4 = CAM_PIN_D4,
-        config.pin_d3 = CAM_PIN_D3,
-        config.pin_d2 = CAM_PIN_D2,
-        config.pin_d1 = CAM_PIN_D1,
-        config.pin_d0 = CAM_PIN_D0,
-        config.pin_vsync = CAM_PIN_VSYNC,
-        config.pin_href = CAM_PIN_HREF,
-        config.pin_pclk = CAM_PIN_PCLK,
+        config.pin_d7 = CAM_PIN_D7;
+        config.pin_d6 = CAM_PIN_D6;
+        config.pin_d5 = CAM_PIN_D5;
+        config.pin_d4 = CAM_PIN_D4;
+        config.pin_d3 = CAM_PIN_D3;
+        config.pin_d2 = CAM_PIN_D2;
+        config.pin_d1 = CAM_PIN_D1;
+        config.pin_d0 = CAM_PIN_D0;
+        config.pin_vsync = CAM_PIN_VSYNC;
+        config.pin_href = CAM_PIN_HREF;
+        config.pin_pclk = CAM_PIN_PCLK;
 
         /* XCLK 20MHz or 10MHz for OV2640 double FPS (Experimental) */
-        config.xclk_freq_hz = 24000000,
-        config.ledc_timer = LEDC_TIMER_0,
-        config.ledc_channel = LEDC_CHANNEL_0,
+        config.xclk_freq_hz = 24000000;
+        config.ledc_timer = LEDC_TIMER_0;
+        config.ledc_channel = LEDC_CHANNEL_0;
 
-        config.pixel_format = PIXFORMAT_RGB565,   /* YUV422,GRAYSCALE,RGB565,JPEG */
-        config.frame_size = FRAMESIZE_QVGA,       /* QQVGA-UXGA, For ESP32, do not use sizes above QVGA when not JPEG. The performance of the ESP32-S series has improved a lot, but JPEG mode always gives better frame rates */
+        config.pixel_format = PIXFORMAT_RGB565;   /* YUV422,GRAYSCALE,RGB565,JPEG */
+        config.frame_size = FRAMESIZE_QVGA;       /* QQVGA-UXGA, For ESP32, do not use sizes above QVGA when not JPEG. The performance of the ESP32-S series has improved a lot, but JPEG mode always gives better frame rates */
 
-        config.jpeg_quality = 12,                 /* 0-63, for OV series camera sensors, lower number means higher quality */
-        config.fb_count = 2,                      /* When jpeg mode is used, if fb_count more than one, the driver will work in continuous mode */
-        config.fb_location = CAMERA_FB_IN_PSRAM,
-        config.grab_mode = CAMERA_GRAB_WHEN_EMPTY,
+        config.jpeg_quality = 12;                 /* 0-63, for OV series camera sensors, lower number means higher quality */
+        config.fb_count = 2;                      /* When jpeg mode is used, if fb_count more than one, the driver will work in continuous mode */
+        config.fb_location = CAMERA_FB_IN_PSRAM;
+        config.grab_mode = CAMERA_GRAB_WHEN_EMPTY;
 
-        camera_ = new Esp32Camera(config);
+        esp_err_t err = esp_camera_init(&config); // 测试相机是否存在
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Camera is not plugged in or not supported, error: %s", esp_err_to_name(err));
+            // 如果摄像头初始化失败，设置 camera_ 为 nullptr
+            camera_ = nullptr;
+            return;
+        }else
+        {
+            esp_camera_deinit();// 释放之前的摄像头资源,为正确初始化做准备
+            camera_ = new Esp32Camera(config);
+        }
+        
     }
 
 public:

--- a/main/boards/atk-dnesp32s3/atk_dnesp32s3.cc
+++ b/main/boards/atk-dnesp32s3/atk_dnesp32s3.cc
@@ -7,6 +7,7 @@
 #include "i2c_device.h"
 #include "iot/thing_manager.h"
 #include "led/single_led.h"
+#include "esp32_camera.h"
 
 #include <esp_log.h>
 #include <esp_lcd_panel_vendor.h>
@@ -54,6 +55,7 @@ private:
     Button boot_button_;
     LcdDisplay* display_;
     XL9555* xl9555_;
+    Esp32Camera* camera_;
 
     void InitializeI2c() {
         // Initialize I2C peripheral
@@ -149,6 +151,52 @@ private:
         thing_manager.AddThing(iot::CreateThing("Screen"));
     }
 
+    // 初始化摄像头：ov2640；
+    // 根据正点原子官方示例参数
+    void InitializeCamera() {
+        
+        xl9555_->SetOutputState(OV_PWDN_IO, 0); // PWDN=低 (上电)
+        xl9555_->SetOutputState(OV_RESET_IO, 0); // 确保复位
+        vTaskDelay(pdMS_TO_TICKS(50));           // 延长复位保持时间
+        xl9555_->SetOutputState(OV_RESET_IO, 1); // 释放复位
+        vTaskDelay(pdMS_TO_TICKS(50));           // 延长 50ms
+
+        camera_config_t config = {};
+
+        config.pin_pwdn = CAM_PIN_PWDN,  // 实际由 XL9555 控制
+        config.pin_reset = CAM_PIN_RESET,// 实际由 XL9555 控制
+        config.pin_xclk = CAM_PIN_XCLK,
+        config.pin_sccb_sda = CAM_PIN_SIOD,
+        config.pin_sccb_scl = CAM_PIN_SIOC,
+
+        config.pin_d7 = CAM_PIN_D7,
+        config.pin_d6 = CAM_PIN_D6,
+        config.pin_d5 = CAM_PIN_D5,
+        config.pin_d4 = CAM_PIN_D4,
+        config.pin_d3 = CAM_PIN_D3,
+        config.pin_d2 = CAM_PIN_D2,
+        config.pin_d1 = CAM_PIN_D1,
+        config.pin_d0 = CAM_PIN_D0,
+        config.pin_vsync = CAM_PIN_VSYNC,
+        config.pin_href = CAM_PIN_HREF,
+        config.pin_pclk = CAM_PIN_PCLK,
+
+        /* XCLK 20MHz or 10MHz for OV2640 double FPS (Experimental) */
+        config.xclk_freq_hz = 24000000,
+        config.ledc_timer = LEDC_TIMER_0,
+        config.ledc_channel = LEDC_CHANNEL_0,
+
+        config.pixel_format = PIXFORMAT_RGB565,   /* YUV422,GRAYSCALE,RGB565,JPEG */
+        config.frame_size = FRAMESIZE_QVGA,       /* QQVGA-UXGA, For ESP32, do not use sizes above QVGA when not JPEG. The performance of the ESP32-S series has improved a lot, but JPEG mode always gives better frame rates */
+
+        config.jpeg_quality = 12,                 /* 0-63, for OV series camera sensors, lower number means higher quality */
+        config.fb_count = 2,                      /* When jpeg mode is used, if fb_count more than one, the driver will work in continuous mode */
+        config.fb_location = CAMERA_FB_IN_PSRAM,
+        config.grab_mode = CAMERA_GRAB_WHEN_EMPTY,
+
+        camera_ = new Esp32Camera(config);
+    }
+
 public:
     atk_dnesp32s3() : boot_button_(BOOT_BUTTON_GPIO) {
         InitializeI2c();
@@ -156,6 +204,7 @@ public:
         InitializeSt7789Display();
         InitializeButtons();
         InitializeIot();
+        InitializeCamera();
     }
 
     virtual Led* GetLed() override {
@@ -182,6 +231,10 @@ public:
 
     virtual Display* GetDisplay() override {
         return display_;
+    }
+    
+    virtual Camera* GetCamera() override {
+        return camera_;
     }
 };
 

--- a/main/boards/atk-dnesp32s3/config.h
+++ b/main/boards/atk-dnesp32s3/config.h
@@ -40,5 +40,25 @@
 #define DISPLAY_BACKLIGHT_PIN GPIO_NUM_NC
 #define DISPLAY_BACKLIGHT_OUTPUT_INVERT true
 
+/* 相机引脚配置 */
+#define CAM_PIN_PWDN    GPIO_NUM_NC
+#define CAM_PIN_RESET   GPIO_NUM_NC
+#define CAM_PIN_VSYNC   GPIO_NUM_47
+#define CAM_PIN_HREF    GPIO_NUM_48
+#define CAM_PIN_PCLK    GPIO_NUM_45
+#define CAM_PIN_XCLK    GPIO_NUM_NC
+#define CAM_PIN_SIOD    GPIO_NUM_39
+#define CAM_PIN_SIOC    GPIO_NUM_38
+#define CAM_PIN_D0      GPIO_NUM_4
+#define CAM_PIN_D1      GPIO_NUM_5
+#define CAM_PIN_D2      GPIO_NUM_6
+#define CAM_PIN_D3      GPIO_NUM_7
+#define CAM_PIN_D4      GPIO_NUM_15
+#define CAM_PIN_D5      GPIO_NUM_16
+#define CAM_PIN_D6      GPIO_NUM_17
+#define CAM_PIN_D7      GPIO_NUM_18
+#define OV_PWDN_IO      4
+#define OV_RESET_IO     5
+
 #endif // _BOARD_CONFIG_H_
 


### PR DESCRIPTION
atk_dnesp32s3添加了相机：
-----------------涉及文件-------------------
config.h: 添加相机引脚定义
atk_dnesp32s3.cc : 添加 InitializeCamera()
----------------------------------------------
依据正点原子官方例程参数。
在ov2640模组上测试通过。
![20250601_211714](https://github.com/user-attachments/assets/e33b03a7-10e1-4cd6-bdfd-7a58e9af8922)
![20250601_211738](https://github.com/user-attachments/assets/dd4bb1b0-8b11-46df-89d9-d44d0a80e415)
