### PR TITLE
feat(esp-hi): update adc mic version

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -29,7 +29,7 @@ dependencies:
   esp_lvgl_port: ~2.6.0
   espressif/esp_io_expander_tca95xx_16bit: ^2.0.0
   espressif2022/image_player: ^1.1.0
-  espressif/adc_mic: ^0.1
+  espressif/adc_mic: ^0.2.0
   espressif/esp_mmap_assets: ">=1.2"
 
   tny-robotics/sh1106-esp-idf:


### PR DESCRIPTION
更新 ADC MIC 版本，将默认的软件增益从 16x 改成 8x，极大的优化了唤醒成功率。并支持更改增益大小