### PR TITLE
fix(esp-hi): fix can not wake up

### DIFF
--- a/main/boards/esp-hi/config.json
+++ b/main/boards/esp-hi/config.json
@@ -8,10 +8,6 @@
                 "CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y",
                 "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v1/4m_esp-hi.csv\"",
                 "CONFIG_BOARD_TYPE_ESP_HI=y",
-                "CONFIG_SR_WN_WN9S_HILEXIN=y",
-                "CONFIG_FL_ANGLE_NEUTRAL=78",
-                "CONFIG_FR_ANGLE_NEUTRAL=108",
-                "CONFIG_BR_ANGLE_NEUTRAL=64",
                 "CONFIG_ESP_WIFI_STATIC_RX_BUFFER_NUM=3",
                 "CONFIG_ESP_WIFI_DYNAMIC_RX_BUFFER_NUM=4",
                 "CONFIG_ESP_WIFI_AMPDU_TX_ENABLED=n",
@@ -31,6 +27,7 @@
                 "CONFIG_NEWLIB_NANO_FORMAT=y",
                 "CONFIG_MMAP_FILE_NAME_LENGTH=25",
                 "CONFIG_ESP_CONSOLE_NONE=y",
+                "CONFIG_USE_ESP_WAKE_WORD=y",
                 "CONFIG_IOT_PROTOCOL_MCP=y"
             ]
         }

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -54,7 +54,7 @@ dependencies:
     rules:
     - if: target in [esp32p4]
   lijunru-hub/servo_dog_ctrl:
-    version: '^0.1.4'
+    version: '^0.1.5'
     rules:
     - if: target in [esp32c3]
 


### PR DESCRIPTION
1. 双唤醒词效果很差，去掉了 hi lexin
2. 修改错误的舵机初始角度
3. 更新舵机控制程序组件版本