### PR TITLE
fix: 延迟 ESP-Hi WebUI 启动时间

### DIFF
--- a/main/boards/esp-hi/config.json
+++ b/main/boards/esp-hi/config.json
@@ -28,7 +28,8 @@
                 "CONFIG_MMAP_FILE_NAME_LENGTH=25",
                 "CONFIG_ESP_CONSOLE_NONE=y",
                 "CONFIG_USE_ESP_WAKE_WORD=y",
-                "CONFIG_IOT_PROTOCOL_MCP=y"
+                "CONFIG_IOT_PROTOCOL_MCP=y",
+                "CONFIG_COMPILER_OPTIMIZATION_SIZE=y"
             ]
         }
     ]


### PR DESCRIPTION
关联 https://github.com/78/xiaozhi-esp32/pull/790

扩大 Main Task Stack Size 之后还是有概率在启动时爆栈，新增了一些缓解措施。