### PR TITLE
fix: fix image player compile error

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -30,7 +30,7 @@ dependencies:
   lvgl/lvgl: ~9.2.2
   esp_lvgl_port: ~2.6.0
   espressif/esp_io_expander_tca95xx_16bit: ^2.0.0
-  espressif2022/image_player: ==1.1.0
+  espressif2022/image_player: ==1.1.0~1
   espressif/adc_mic: ^0.2.0
   espressif/esp_mmap_assets: '>=1.2'
   txp666/otto-emoji-gif-component: ~1.0.2


### PR DESCRIPTION
修复 https://github.com/78/xiaozhi-esp32/pull/931 引入的编译错误