### PR TITLE
修复 AtomS3 背光控制

### DIFF
--- a/main/boards/atoms3-echo-base/atoms3_echo_base.cc
+++ b/main/boards/atoms3-echo-base/atoms3_echo_base.cc
@@ -229,7 +229,7 @@ public:
     }
 
     virtual Backlight* GetBacklight() override {
-        static PwmBacklight backlight(DISPLAY_BACKLIGHT_PIN, DISPLAY_BACKLIGHT_OUTPUT_INVERT);
+        static PwmBacklight backlight(DISPLAY_BACKLIGHT_PIN, DISPLAY_BACKLIGHT_OUTPUT_INVERT, 256);
         return &backlight;
     }
 };

--- a/main/boards/common/backlight.cc
+++ b/main/boards/common/backlight.cc
@@ -81,12 +81,12 @@ void Backlight::OnTransitionTimer() {
     }
 }
 
-PwmBacklight::PwmBacklight(gpio_num_t pin, bool output_invert) : Backlight() {
+PwmBacklight::PwmBacklight(gpio_num_t pin, bool output_invert, uint32_t freq_hz) : Backlight() {
     const ledc_timer_config_t backlight_timer = {
         .speed_mode = LEDC_LOW_SPEED_MODE,
         .duty_resolution = LEDC_TIMER_10_BIT,
         .timer_num = LEDC_TIMER_0,
-        .freq_hz = 25000, //背光pwm频率需要高一点，防止电感啸叫
+        .freq_hz = freq_hz, //背光pwm频率需要高一点，防止电感啸叫
         .clk_cfg = LEDC_AUTO_CLK,
         .deconfigure = false
     };

--- a/main/boards/common/backlight.h
+++ b/main/boards/common/backlight.h
@@ -29,7 +29,7 @@ protected:
 
 class PwmBacklight : public Backlight {
 public:
-    PwmBacklight(gpio_num_t pin, bool output_invert = false);
+    PwmBacklight(gpio_num_t pin, bool output_invert = false, uint32_t freq_hz = 25000);
     ~PwmBacklight();
 
     void SetBrightnessImpl(uint8_t brightness) override;


### PR DESCRIPTION
因为 [AtomS3](https://docs.m5stack.com/zh_CN/core/AtomS3) 的背光控制不支持高频 PWM，所以在 `PwmBacklight` 上加了频率的传参


<img width="1178" height="301" alt="image" src="https://github.com/user-attachments/assets/8f318ec0-261a-4772-83ec-3e3c6ad55ea2" />
