### PR TITLE
fix esp-hi crashing in esp_codec_dev_close()

### DIFF
--- a/main/boards/esp-hi/adc_pdm_audio_codec.cc
+++ b/main/boards/esp-hi/adc_pdm_audio_codec.cc
@@ -141,7 +141,8 @@ void AdcPdmAudioCodec::EnableInput(bool enable) {
         };
         ESP_ERROR_CHECK(esp_codec_dev_open(input_dev_, &fs));
     } else {
-        ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
+        // ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
+        return;
     }
     AudioCodec::EnableInput(enable);
 }


### PR DESCRIPTION
@laride 看看这个，PDM mic 在 open 之后，如果 close 会崩溃