### PR TITLE
feat(board): 添加 SG90 舵机语音控制板支持

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -214,6 +214,8 @@ elseif(CONFIG_BOARD_TYPE_LABPLUS_LEDONG_V2)
     set(BOARD_TYPE "labplus-ledong-v2") 
 elseif(CONFIG_BOARD_TYPE_SURFER_C3_1_14TFT)
     set(BOARD_TYPE "surfer-c3-1.14tft")
+elseif(CONFIG_BOARD_TYPE_SG90_SERVO_VOICE)
+    set(BOARD_TYPE "sg90-servo-voice")
 endif()
 file(GLOB BOARD_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/boards/${BOARD_TYPE}/*.cc

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -302,6 +302,9 @@ choice BOARD_TYPE
     config BOARD_TYPE_SURFER_C3_1_14TFT
         bool "Surfer-C3-1-14TFT"
         depends on IDF_TARGET_ESP32C3
+    config BOARD_TYPE_SG90_SERVO_VOICE
+        bool "SG90舵机语音控制板"
+        depends on IDF_TARGET_ESP32S3
 endchoice
 
 choice ESP_S3_LCD_EV_Board_Version_TYPE

--- a/main/boards/sg90-servo-voice/README.md
+++ b/main/boards/sg90-servo-voice/README.md
@@ -1,0 +1,102 @@
+# SG90 舵机语音控制板
+
+## 概述
+
+这是一个小智语音控制 SG90 的示例代码，支持通过语音指令控制舵机的角度和运动。
+
+## 硬件配置
+
+硬件配置和小智 AI 的面包接线方式完全相同。 可以参考 [小智 AI 聊天机器人面包板 DIY 硬件清单与接线教程](https://ccnphfhqs21z.feishu.cn/wiki/EH6wwrgvNiU7aykr7HgclP09nCh)
+**唯一区别是需要连接一个 SG90 舵机**
+
+舵机一般有三根线：
+
+| 颜色   | 含义           |
+| ------ | -------------- |
+| 橙色   | 表示信号线     |
+| 红色   | 表示电源正极线 |
+| 咖啡色 | 表示电源负极线 |
+
+舵机和开发板的接线方式如下
+
+| ESP32S3 开发板 | SG90 舵机    |
+| -------------- | ------------ |
+| GPIO18         | 橙色信号线   |
+| 3V3 电源       | 红色正极线   |
+| GND            | 咖啡色负极线 |
+
+### MCP 工具列表
+
+- `self.servo.set_angle` - 设置舵机角度
+- `self.servo.rotate_clockwise` - 顺时针旋转
+- `self.servo.rotate_counterclockwise` - 逆时针旋转
+- `self.servo.get_position` - 获取当前位置
+- `self.servo.stop` - 停止舵机
+- `self.servo.sweep` - 扫描模式
+- `self.servo.reset` - 复位到中心位置
+
+## 编译和烧录
+
+编译和烧录有两种方式，一种是直接编译出固件(一般在发布阶段使用)，一种是手动编译和烧录（一般在开发阶段使用）
+
+### 方式一：直接编译出固件
+
+**第一步：设置 ESP-IDF 环境**:
+
+```bash
+source /path/to/esp-idf/export.sh
+```
+
+**第二步：编译固件**:
+
+```bash
+python scripts/release.py sg90-servo-voice
+```
+
+提示：生成的固件文件在: `releases/v1.8.1_sg90-servo-voice.zip`
+
+### 方式二：手动编译和烧录
+
+**第一步：设置 ESP-IDF 环境**:
+
+```bash
+source /path/to/esp-idf/export.sh
+```
+
+**第二步：设置芯片**
+
+```bash
+idf.py set-target esp32s3
+```
+
+**第三步：设置开发板**
+
+```bash
+idf.py menuconfig
+
+# 然后依次选择：Xiaozhi Assistant -> Board Type -> SG90舵机语音控制板（一般在最后一个）
+```
+
+**第三步：编译固件**
+
+```bash
+idf.py build
+```
+
+**第三步：烧录与监控器**
+
+```bash
+idf.py flash monitor
+```
+
+### 语音控制
+
+设备配置完成后，可以使用以下语音指令试一下：
+
+- **"设置舵机角度到 90 度"** - 设置舵机到指定角度
+- **"顺时针旋转 45 度"** - 顺时针旋转指定角度
+- **"逆时针旋转 30 度"** - 逆时针旋转指定角度
+- **"开始扫描模式"** - 在 0-180 度范围内来回摆动
+- **"停止舵机"** - 立即停止舵机运动
+- **"复位舵机"** - 回到中心位置（90 度）
+- **"查看舵机状态"** - 获取当前角度和运动状态

--- a/main/boards/sg90-servo-voice/config.h
+++ b/main/boards/sg90-servo-voice/config.h
@@ -1,0 +1,80 @@
+#ifndef _BOARD_CONFIG_H_
+#define _BOARD_CONFIG_H_
+
+#include <driver/gpio.h>
+
+// 音频配置
+#define AUDIO_INPUT_SAMPLE_RATE  16000
+#define AUDIO_OUTPUT_SAMPLE_RATE 24000
+
+// 使用 Simplex I2S 模式（麦克风输入 + 可选扬声器输出）
+#define AUDIO_I2S_METHOD_SIMPLEX
+
+#ifdef AUDIO_I2S_METHOD_SIMPLEX
+
+// 麦克风输入引脚 (INMP441)
+// ESP32-S3 ↔ INMP441: GPIO4(WS), GPIO5(SCK), GPIO6(SD)
+#define AUDIO_I2S_MIC_GPIO_WS   GPIO_NUM_4
+#define AUDIO_I2S_MIC_GPIO_SCK  GPIO_NUM_5
+#define AUDIO_I2S_MIC_GPIO_DIN  GPIO_NUM_6
+
+// 扬声器输出引脚 (MAX98357A)
+// ESP32-S3 ↔ MAX98357A: GPIO7(DIN), GPIO15(BCLK), GPIO16(LRC)
+#define AUDIO_I2S_SPK_GPIO_DOUT GPIO_NUM_7
+#define AUDIO_I2S_SPK_GPIO_BCLK GPIO_NUM_15
+#define AUDIO_I2S_SPK_GPIO_LRCK GPIO_NUM_16
+
+#else
+
+// Duplex I2S 模式引脚
+#define AUDIO_I2S_GPIO_WS GPIO_NUM_4
+#define AUDIO_I2S_GPIO_BCLK GPIO_NUM_5
+#define AUDIO_I2S_GPIO_DIN  GPIO_NUM_6
+#define AUDIO_I2S_GPIO_DOUT GPIO_NUM_7
+
+#endif
+
+// 控制按钮引脚
+#define BOOT_BUTTON_GPIO        GPIO_NUM_0
+#define TOUCH_BUTTON_GPIO       GPIO_NUM_5
+#define ASR_BUTTON_GPIO         GPIO_NUM_19
+
+// 状态指示LED
+#define BUILTIN_LED_GPIO        GPIO_NUM_2
+
+// 显示屏引脚（可选OLED）
+#define DISPLAY_SDA_PIN GPIO_NUM_4
+#define DISPLAY_SCL_PIN GPIO_NUM_15
+#define DISPLAY_WIDTH   128
+
+#if CONFIG_OLED_SSD1306_128X32
+#define DISPLAY_HEIGHT  32
+#elif CONFIG_OLED_SSD1306_128X64
+#define DISPLAY_HEIGHT  64
+#else
+// 默认使用64像素高度，如果没有显示屏则在代码中处理
+#define DISPLAY_HEIGHT  64
+#endif
+
+#define DISPLAY_MIRROR_X true
+#define DISPLAY_MIRROR_Y true
+
+// SG90舵机控制引脚
+#define SERVO_GPIO GPIO_NUM_18
+
+// 舵机参数配置
+#define SERVO_MIN_PULSEWIDTH_US 500           // 最小脉宽（微秒）对应0度
+#define SERVO_MAX_PULSEWIDTH_US 2500          // 最大脉宽（微秒）对应180度
+#define SERVO_MIN_DEGREE 0                    // 最小角度
+#define SERVO_MAX_DEGREE 180                  // 最大角度
+#define SERVO_TIMEBASE_RESOLUTION_HZ 1000000  // 1MHz, 1us per tick
+#define SERVO_TIMEBASE_PERIOD 20000           // 20000 ticks, 20ms (50Hz)
+
+// 舵机默认位置和限制
+#define SERVO_DEFAULT_ANGLE 90                // 默认中心位置
+#define SERVO_MAX_SPEED_DEGREE_PER_SEC 180    // 最大转速限制
+
+// 板子版本信息
+#define SG90_SERVO_VOICE_VERSION "1.0.0"
+
+#endif // _BOARD_CONFIG_H_

--- a/main/boards/sg90-servo-voice/config.json
+++ b/main/boards/sg90-servo-voice/config.json
@@ -1,0 +1,10 @@
+{
+    "target": "esp32s3",
+    "builds": [
+        {
+            "name": "sg90-servo-voice",
+            "sdkconfig_append": [
+            ]
+        }
+    ]
+}

--- a/main/boards/sg90-servo-voice/servo_controller.cc
+++ b/main/boards/sg90-servo-voice/servo_controller.cc
@@ -1,0 +1,309 @@
+#include "servo_controller.h"
+#include <esp_log.h>
+#include <cmath>
+
+#define TAG "ServoController"
+
+ServoController::ServoController(gpio_num_t servo_pin)
+    : servo_pin_(servo_pin)
+    , ledc_channel_(LEDC_CHANNEL_0)
+    , ledc_timer_(LEDC_TIMER_0)
+    , current_angle_(SERVO_DEFAULT_ANGLE)
+    , target_angle_(SERVO_DEFAULT_ANGLE)
+    , is_moving_(false)
+    , is_sweeping_(false)
+    , stop_requested_(false)
+    , servo_task_handle_(nullptr)
+    , command_queue_(nullptr)
+    , on_move_complete_callback_(nullptr) {
+}
+
+ServoController::~ServoController() {
+    Stop();
+    if (servo_task_handle_ != nullptr) {
+        vTaskDelete(servo_task_handle_);
+    }
+    if (command_queue_ != nullptr) {
+        vQueueDelete(command_queue_);
+    }
+}
+
+bool ServoController::Initialize() {
+    ESP_LOGI(TAG, "初始化SG90舵机控制器，引脚: %d", servo_pin_);
+    
+    // 配置LEDC定时器 (ESP32-S3最大支持14位分辨率)
+    ledc_timer_config_t timer_config = {
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .duty_resolution = LEDC_TIMER_14_BIT,
+        .timer_num = ledc_timer_,
+        .freq_hz = 50, // 50Hz for servo
+        .clk_cfg = LEDC_AUTO_CLK
+    };
+    
+    esp_err_t ret = ledc_timer_config(&timer_config);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "LEDC定时器配置失败: %s", esp_err_to_name(ret));
+        return false;
+    }
+    
+    // 配置LEDC通道
+    ledc_channel_config_t channel_config = {
+        .gpio_num = servo_pin_,
+        .speed_mode = LEDC_LOW_SPEED_MODE,
+        .channel = ledc_channel_,
+        .intr_type = LEDC_INTR_DISABLE,
+        .timer_sel = ledc_timer_,
+        .duty = 0,
+        .hpoint = 0
+    };
+    
+    ret = ledc_channel_config(&channel_config);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "LEDC通道配置失败: %s", esp_err_to_name(ret));
+        return false;
+    }
+    
+    // 创建命令队列
+    command_queue_ = xQueueCreate(10, sizeof(ServoCommand));
+    if (command_queue_ == nullptr) {
+        ESP_LOGE(TAG, "创建命令队列失败");
+        return false;
+    }
+    
+    // 创建舵机控制任务
+    BaseType_t task_ret = xTaskCreate(
+        ServoTask,
+        "servo_task",
+        4096,
+        this,
+        5,
+        &servo_task_handle_
+    );
+    
+    if (task_ret != pdPASS) {
+        ESP_LOGE(TAG, "创建舵机任务失败");
+        return false;
+    }
+    
+    // 设置初始位置
+    WriteAngle(current_angle_);
+    
+    ESP_LOGI(TAG, "SG90舵机控制器初始化成功");
+    return true;
+}
+
+void ServoController::SetAngle(int angle) {
+    if (!IsValidAngle(angle)) {
+        ESP_LOGW(TAG, "无效角度: %d，将限制在有效范围内", angle);
+        angle = ConstrainAngle(angle);
+    }
+    
+    ServoCommand cmd = {CMD_SET_ANGLE, angle, 0, 0};
+    xQueueSend(command_queue_, &cmd, portMAX_DELAY);
+}
+
+void ServoController::RotateClockwise(int degrees) {
+    if (degrees <= 0) {
+        ESP_LOGW(TAG, "旋转角度必须大于0");
+        return;
+    }
+    
+    ServoCommand cmd = {CMD_ROTATE_CW, degrees, 0, 0};
+    xQueueSend(command_queue_, &cmd, portMAX_DELAY);
+}
+
+void ServoController::RotateCounterclockwise(int degrees) {
+    if (degrees <= 0) {
+        ESP_LOGW(TAG, "旋转角度必须大于0");
+        return;
+    }
+    
+    ServoCommand cmd = {CMD_ROTATE_CCW, degrees, 0, 0};
+    xQueueSend(command_queue_, &cmd, portMAX_DELAY);
+}
+
+void ServoController::SweepBetween(int min_angle, int max_angle, int speed_ms) {
+    if (!IsValidAngle(min_angle) || !IsValidAngle(max_angle)) {
+        ESP_LOGW(TAG, "扫描角度范围无效: %d - %d", min_angle, max_angle);
+        return;
+    }
+    
+    if (min_angle >= max_angle) {
+        ESP_LOGW(TAG, "最小角度必须小于最大角度");
+        return;
+    }
+    
+    ServoCommand cmd = {CMD_SWEEP, min_angle, max_angle, speed_ms};
+    xQueueSend(command_queue_, &cmd, portMAX_DELAY);
+}
+
+void ServoController::Stop() {
+    stop_requested_ = true;
+    ServoCommand cmd = {CMD_STOP, 0, 0, 0};
+    xQueueSend(command_queue_, &cmd, 0); // 不等待，立即发送停止命令
+}
+
+void ServoController::Reset() {
+    ServoCommand cmd = {CMD_RESET, SERVO_DEFAULT_ANGLE, 0, 0};
+    xQueueSend(command_queue_, &cmd, portMAX_DELAY);
+}
+
+void ServoController::WriteAngle(int angle) {
+    angle = ConstrainAngle(angle);
+    uint32_t compare_value = AngleToCompare(angle);
+    ledc_set_duty(LEDC_LOW_SPEED_MODE, ledc_channel_, compare_value);
+    ledc_update_duty(LEDC_LOW_SPEED_MODE, ledc_channel_);
+    current_angle_ = angle;
+}
+
+uint32_t ServoController::AngleToCompare(int angle) {
+    // 将角度转换为PWM占空比
+    // SG90: 0.5ms-2.5ms 对应 0-180度
+    // 50Hz周期 = 20ms
+    // 占空比 = (脉宽 / 周期) * 2^14 (ESP32-S3使用14位分辨率)
+
+    float pulse_width_ms = 0.5f + (angle / 180.0f) * 2.0f; // 0.5ms to 2.5ms
+    float duty_cycle = pulse_width_ms / 20.0f; // 20ms period
+    uint32_t compare_value = (uint32_t)(duty_cycle * 16383); // 14-bit resolution (2^14 - 1)
+
+    return compare_value;
+}
+
+bool ServoController::IsValidAngle(int angle) const {
+    return angle >= SERVO_MIN_DEGREE && angle <= SERVO_MAX_DEGREE;
+}
+
+int ServoController::ConstrainAngle(int angle) const {
+    if (angle < SERVO_MIN_DEGREE) return SERVO_MIN_DEGREE;
+    if (angle > SERVO_MAX_DEGREE) return SERVO_MAX_DEGREE;
+    return angle;
+}
+
+void ServoController::ServoTask(void* parameter) {
+    ServoController* controller = static_cast<ServoController*>(parameter);
+    controller->ProcessCommands();
+}
+
+void ServoController::ProcessCommands() {
+    ServoCommand cmd;
+    
+    while (true) {
+        if (xQueueReceive(command_queue_, &cmd, pdMS_TO_TICKS(100)) == pdTRUE) {
+            if (stop_requested_ && cmd.type != CMD_STOP) {
+                continue; // 忽略非停止命令
+            }
+            
+            switch (cmd.type) {
+                case CMD_SET_ANGLE:
+                    ExecuteSetAngle(cmd.param1);
+                    break;
+                    
+                case CMD_ROTATE_CW:
+                    ExecuteRotate(cmd.param1, true);
+                    break;
+                    
+                case CMD_ROTATE_CCW:
+                    ExecuteRotate(cmd.param1, false);
+                    break;
+                    
+                case CMD_SWEEP:
+                    ExecuteSweep(cmd.param1, cmd.param2, cmd.param3);
+                    break;
+                    
+                case CMD_STOP:
+                    is_moving_ = false;
+                    is_sweeping_ = false;
+                    stop_requested_ = false;
+                    ESP_LOGI(TAG, "舵机停止");
+                    break;
+                    
+                case CMD_RESET:
+                    ExecuteSetAngle(cmd.param1);
+                    break;
+            }
+        }
+    }
+}
+
+void ServoController::ExecuteSetAngle(int angle) {
+    ESP_LOGI(TAG, "设置舵机角度: %d度", angle);
+    is_moving_ = true;
+    SmoothMoveTo(angle, 500);
+    is_moving_ = false;
+
+    if (on_move_complete_callback_) {
+        on_move_complete_callback_();
+    }
+}
+
+void ServoController::ExecuteRotate(int degrees, bool clockwise) {
+    int target = current_angle_ + (clockwise ? degrees : -degrees);
+    target = ConstrainAngle(target);
+
+    ESP_LOGI(TAG, "%s旋转 %d度，从 %d度 到 %d度",
+             clockwise ? "顺时针" : "逆时针", degrees, current_angle_, target);
+
+    is_moving_ = true;
+    SmoothMoveTo(target, 500);
+    is_moving_ = false;
+
+    if (on_move_complete_callback_) {
+        on_move_complete_callback_();
+    }
+}
+
+void ServoController::ExecuteSweep(int min_angle, int max_angle, int speed_ms) {
+    ESP_LOGI(TAG, "开始扫描模式: %d度 - %d度，速度: %dms", min_angle, max_angle, speed_ms);
+
+    is_sweeping_ = true;
+    is_moving_ = true;
+
+    bool direction = true; // true = 向最大角度，false = 向最小角度
+
+    while (is_sweeping_ && !stop_requested_) {
+        int target = direction ? max_angle : min_angle;
+        SmoothMoveTo(target, speed_ms);
+
+        if (stop_requested_) break;
+
+        direction = !direction;
+        vTaskDelay(pdMS_TO_TICKS(100)); // 短暂停顿
+    }
+
+    is_sweeping_ = false;
+    is_moving_ = false;
+
+    ESP_LOGI(TAG, "扫描模式结束");
+
+    if (on_move_complete_callback_) {
+        on_move_complete_callback_();
+    }
+}
+
+void ServoController::SmoothMoveTo(int target_angle, int speed_ms) {
+    target_angle = ConstrainAngle(target_angle);
+
+    if (target_angle == current_angle_) {
+        return; // 已经在目标位置
+    }
+
+    int start_angle = current_angle_;
+    int angle_diff = target_angle - start_angle;
+    int steps = abs(angle_diff);
+
+    if (steps == 0) return;
+
+    int delay_per_step = speed_ms / steps;
+    if (delay_per_step < 10) delay_per_step = 10; // 最小延迟
+
+    for (int i = 1; i <= steps && !stop_requested_; i++) {
+        int current_step_angle = start_angle + (angle_diff * i) / steps;
+        WriteAngle(current_step_angle);
+        vTaskDelay(pdMS_TO_TICKS(delay_per_step));
+    }
+
+    // 确保到达精确位置
+    if (!stop_requested_) {
+        WriteAngle(target_angle);
+    }
+}

--- a/main/boards/sg90-servo-voice/servo_controller.h
+++ b/main/boards/sg90-servo-voice/servo_controller.h
@@ -1,0 +1,92 @@
+#ifndef __SERVO_CONTROLLER_H__
+#define __SERVO_CONTROLLER_H__
+
+#include <driver/ledc.h>
+#include <driver/gpio.h>
+#include <esp_log.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <freertos/queue.h>
+#include <functional>
+#include "config.h"
+
+class ServoController {
+public:
+    ServoController(gpio_num_t servo_pin);
+    ~ServoController();
+
+    // 基本控制方法
+    bool Initialize();
+    void SetAngle(int angle);
+    int GetCurrentAngle() const { return current_angle_; }
+    
+    // 运动控制方法
+    void RotateClockwise(int degrees);
+    void RotateCounterclockwise(int degrees);
+    void SweepBetween(int min_angle, int max_angle, int speed_ms = 1000);
+    void Stop();
+    void Reset(); // 回到中心位置（90度）
+    
+    // 状态查询
+    bool IsMoving() const { return is_moving_; }
+    bool IsSweeping() const { return is_sweeping_; }
+    
+    // 设置回调函数（当运动完成时调用）
+    void SetOnMoveCompleteCallback(std::function<void()> callback) {
+        on_move_complete_callback_ = callback;
+    }
+
+private:
+    // 硬件相关
+    gpio_num_t servo_pin_;
+    ledc_channel_t ledc_channel_;
+    ledc_timer_t ledc_timer_;
+    
+    // 状态变量
+    int current_angle_;
+    int target_angle_;
+    bool is_moving_;
+    bool is_sweeping_;
+    bool stop_requested_;
+    
+    // 任务和队列
+    TaskHandle_t servo_task_handle_;
+    QueueHandle_t command_queue_;
+    
+    // 回调函数
+    std::function<void()> on_move_complete_callback_;
+    
+    // 命令类型
+    enum CommandType {
+        CMD_SET_ANGLE,
+        CMD_ROTATE_CW,
+        CMD_ROTATE_CCW,
+        CMD_SWEEP,
+        CMD_STOP,
+        CMD_RESET
+    };
+    
+    // 命令结构
+    struct ServoCommand {
+        CommandType type;
+        int param1;  // 角度或度数
+        int param2;  // 最大角度（用于扫描）或速度
+        int param3;  // 速度参数
+    };
+    
+    // 私有方法
+    void WriteAngle(int angle);
+    uint32_t AngleToCompare(int angle);
+    bool IsValidAngle(int angle) const;
+    int ConstrainAngle(int angle) const;
+    
+    // 任务函数
+    static void ServoTask(void* parameter);
+    void ProcessCommands();
+    void ExecuteSetAngle(int angle);
+    void ExecuteRotate(int degrees, bool clockwise);
+    void ExecuteSweep(int min_angle, int max_angle, int speed_ms);
+    void SmoothMoveTo(int target_angle, int speed_ms = 500);
+};
+
+#endif // __SERVO_CONTROLLER_H__

--- a/main/boards/sg90-servo-voice/sg90_servo_voice_board.cc
+++ b/main/boards/sg90-servo-voice/sg90_servo_voice_board.cc
@@ -1,0 +1,324 @@
+#include "wifi_board.h"
+#include "codecs/no_audio_codec.h"
+#include "system_reset.h"
+#include "application.h"
+#include "button.h"
+#include "config.h"
+#include "mcp_server.h"
+#include "led/single_led.h"
+#include "display/oled_display.h"
+#include "display/display.h"
+#include "servo_controller.h"
+
+#include <wifi_station.h>
+#include <esp_log.h>
+#include <driver/i2c_master.h>
+#include <esp_lcd_panel_ops.h>
+#include <esp_lcd_panel_vendor.h>
+
+#define TAG "SG90ServoVoice"
+
+LV_FONT_DECLARE(font_puhui_14_1);
+LV_FONT_DECLARE(font_awesome_14_1);
+
+class SG90ServoVoiceBoard : public WifiBoard {
+private:
+    Button boot_button_;
+    Button touch_button_;
+    Button asr_button_;
+    
+    ServoController* servo_controller_;
+    
+    // 显示相关（可选）
+    i2c_master_bus_handle_t display_i2c_bus_;
+    esp_lcd_panel_io_handle_t panel_io_ = nullptr;
+    esp_lcd_panel_handle_t panel_ = nullptr;
+    Display* display_ = nullptr;
+    bool display_enabled_ = false;
+
+    void InitializeDisplayI2c() {
+        i2c_master_bus_config_t bus_config = {
+            .i2c_port = (i2c_port_t)0,
+            .sda_io_num = DISPLAY_SDA_PIN,
+            .scl_io_num = DISPLAY_SCL_PIN,
+            .clk_source = I2C_CLK_SRC_DEFAULT,
+            .glitch_ignore_cnt = 7,
+            .intr_priority = 0,
+            .trans_queue_depth = 0,
+            .flags = {
+                .enable_internal_pullup = 1,
+            },
+        };
+        
+        esp_err_t ret = i2c_new_master_bus(&bus_config, &display_i2c_bus_);
+        if (ret != ESP_OK) {
+            ESP_LOGW(TAG, "I2C总线初始化失败，禁用显示屏: %s", esp_err_to_name(ret));
+            display_enabled_ = false;
+            return;
+        }
+        display_enabled_ = true;
+    }
+
+    void InitializeSsd1306Display() {
+        if (!display_enabled_) {
+            display_ = new NoDisplay();
+            return;
+        }
+        
+        // SSD1306 config
+        esp_lcd_panel_io_i2c_config_t io_config = {
+            .dev_addr = 0x3C,
+            .on_color_trans_done = nullptr,
+            .user_ctx = nullptr,
+            .control_phase_bytes = 1,
+            .dc_bit_offset = 6,
+            .lcd_cmd_bits = 8,
+            .lcd_param_bits = 8,
+            .flags = {
+                .dc_low_on_data = 0,
+                .disable_control_phase = 0,
+            },
+            .scl_speed_hz = 400 * 1000,
+        };
+
+        esp_err_t ret = esp_lcd_new_panel_io_i2c_v2(display_i2c_bus_, &io_config, &panel_io_);
+        if (ret != ESP_OK) {
+            ESP_LOGW(TAG, "显示屏IO初始化失败，使用无显示模式: %s", esp_err_to_name(ret));
+            display_ = new NoDisplay();
+            return;
+        }
+
+        ESP_LOGI(TAG, "安装SSD1306驱动");
+        esp_lcd_panel_dev_config_t panel_config = {};
+        panel_config.reset_gpio_num = -1;
+        panel_config.bits_per_pixel = 1;
+
+        esp_lcd_panel_ssd1306_config_t ssd1306_config = {
+            .height = static_cast<uint8_t>(DISPLAY_HEIGHT),
+        };
+        panel_config.vendor_config = &ssd1306_config;
+
+        ret = esp_lcd_new_panel_ssd1306(panel_io_, &panel_config, &panel_);
+        if (ret != ESP_OK) {
+            ESP_LOGW(TAG, "SSD1306面板创建失败，使用无显示模式: %s", esp_err_to_name(ret));
+            display_ = new NoDisplay();
+            return;
+        }
+
+        ESP_LOGI(TAG, "SSD1306驱动安装成功");
+
+        // Reset the display
+        ESP_ERROR_CHECK(esp_lcd_panel_reset(panel_));
+        if (esp_lcd_panel_init(panel_) != ESP_OK) {
+            ESP_LOGE(TAG, "显示屏初始化失败，使用无显示模式");
+            display_ = new NoDisplay();
+            return;
+        }
+
+        // Set the display to on
+        ESP_LOGI(TAG, "开启显示屏");
+        ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel_, true));
+
+        display_ = new OledDisplay(panel_io_, panel_, DISPLAY_WIDTH, DISPLAY_HEIGHT, 
+                                   DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y,
+                                   {&font_puhui_14_1, &font_awesome_14_1});
+    }
+
+    void InitializeButtons() {
+        // 配置内置LED GPIO
+        gpio_config_t io_conf = {
+            .pin_bit_mask = 1ULL << BUILTIN_LED_GPIO,
+            .mode = GPIO_MODE_OUTPUT,
+            .pull_up_en = GPIO_PULLUP_DISABLE,
+            .pull_down_en = GPIO_PULLDOWN_DISABLE,
+            .intr_type = GPIO_INTR_DISABLE
+        };
+        gpio_config(&io_conf);
+
+        boot_button_.OnClick([this]() {
+            auto& app = Application::GetInstance();
+            if (app.GetDeviceState() == kDeviceStateStarting && 
+                !WifiStation::GetInstance().IsConnected()) {
+                ResetWifiConfiguration();
+            }
+            gpio_set_level(BUILTIN_LED_GPIO, 1);
+            app.ToggleChatState();
+        });
+
+        asr_button_.OnClick([this]() {
+            std::string wake_word = "你好小智";
+            Application::GetInstance().WakeWordInvoke(wake_word);
+        });
+
+        touch_button_.OnPressDown([this]() {
+            gpio_set_level(BUILTIN_LED_GPIO, 1);
+            Application::GetInstance().StartListening();
+        });
+        
+        touch_button_.OnPressUp([this]() {
+            gpio_set_level(BUILTIN_LED_GPIO, 0);
+            Application::GetInstance().StopListening();
+        });
+    }
+
+    void InitializeServoController() {
+        ESP_LOGI(TAG, "初始化SG90舵机控制器");
+        servo_controller_ = new ServoController(SERVO_GPIO);
+        
+        if (!servo_controller_->Initialize()) {
+            ESP_LOGE(TAG, "舵机控制器初始化失败");
+            delete servo_controller_;
+            servo_controller_ = nullptr;
+            return;
+        }
+        
+        // 设置运动完成回调（可选，用于状态指示）
+        servo_controller_->SetOnMoveCompleteCallback([this]() {
+            // 运动完成时闪烁LED
+            gpio_set_level(BUILTIN_LED_GPIO, 1);
+            vTaskDelay(pdMS_TO_TICKS(100));
+            gpio_set_level(BUILTIN_LED_GPIO, 0);
+        });
+        
+        RegisterServoMcpTools();
+        ESP_LOGI(TAG, "SG90舵机控制器初始化完成");
+    }
+
+    void RegisterServoMcpTools() {
+        if (servo_controller_ == nullptr) {
+            ESP_LOGW(TAG, "舵机控制器未初始化，跳过MCP工具注册");
+            return;
+        }
+        
+        auto& mcp_server = McpServer::GetInstance();
+        ESP_LOGI(TAG, "开始注册舵机MCP工具...");
+
+        // 设置舵机角度
+        mcp_server.AddTool("self.servo.set_angle",
+                           "设置SG90舵机到指定角度。angle: 目标角度(0-180度)",
+                           PropertyList({Property("angle", kPropertyTypeInteger, 90, 0, 180)}),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               int angle = properties["angle"].value<int>();
+                               servo_controller_->SetAngle(angle);
+                               return "舵机设置到 " + std::to_string(angle) + " 度";
+                           });
+
+        // 顺时针旋转
+        mcp_server.AddTool("self.servo.rotate_clockwise",
+                           "顺时针旋转SG90舵机指定角度。degrees: 旋转角度(1-180度)",
+                           PropertyList({Property("degrees", kPropertyTypeInteger, 30, 1, 180)}),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               int degrees = properties["degrees"].value<int>();
+                               servo_controller_->RotateClockwise(degrees);
+                               return "舵机顺时针旋转 " + std::to_string(degrees) + " 度";
+                           });
+
+        // 逆时针旋转
+        mcp_server.AddTool("self.servo.rotate_counterclockwise",
+                           "逆时针旋转SG90舵机指定角度。degrees: 旋转角度(1-180度)",
+                           PropertyList({Property("degrees", kPropertyTypeInteger, 30, 1, 180)}),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               int degrees = properties["degrees"].value<int>();
+                               servo_controller_->RotateCounterclockwise(degrees);
+                               return "舵机逆时针旋转 " + std::to_string(degrees) + " 度";
+                           });
+
+        // 获取当前位置
+        mcp_server.AddTool("self.servo.get_position",
+                           "获取SG90舵机当前角度位置",
+                           PropertyList(),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               int angle = servo_controller_->GetCurrentAngle();
+                               return "当前舵机角度: " + std::to_string(angle) + " 度";
+                           });
+
+        // 扫描模式
+        mcp_server.AddTool("self.servo.sweep",
+                           "SG90舵机扫描模式，在指定角度范围内来回摆动。"
+                           "min_angle: 最小角度(0-179度); max_angle: 最大角度(1-180度); "
+                           "speed: 摆动速度，毫秒(100-5000ms)",
+                           PropertyList({Property("min_angle", kPropertyTypeInteger, 0, 0, 179),
+                                         Property("max_angle", kPropertyTypeInteger, 180, 1, 180),
+                                         Property("speed", kPropertyTypeInteger, 1000, 100, 5000)}),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               int min_angle = properties["min_angle"].value<int>();
+                               int max_angle = properties["max_angle"].value<int>();
+                               int speed = properties["speed"].value<int>();
+                               servo_controller_->SweepBetween(min_angle, max_angle, speed);
+                               return "开始扫描模式: " + std::to_string(min_angle) + "° - " + 
+                                      std::to_string(max_angle) + "°";
+                           });
+
+        // 停止舵机
+        mcp_server.AddTool("self.servo.stop",
+                           "立即停止SG90舵机运动",
+                           PropertyList(),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               servo_controller_->Stop();
+                               return "舵机已停止";
+                           });
+
+        // 复位到中心位置
+        mcp_server.AddTool("self.servo.reset",
+                           "将SG90舵机复位到中心位置(90度)",
+                           PropertyList(),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               servo_controller_->Reset();
+                               return "舵机已复位到中心位置(90度)";
+                           });
+
+        // 获取舵机状态
+        mcp_server.AddTool("self.servo.get_status",
+                           "获取SG90舵机当前状态",
+                           PropertyList(),
+                           [this](const PropertyList& properties) -> ReturnValue {
+                               int angle = servo_controller_->GetCurrentAngle();
+                               bool moving = servo_controller_->IsMoving();
+                               bool sweeping = servo_controller_->IsSweeping();
+                               
+                               std::string status = "{\"angle\":" + std::to_string(angle) +
+                                                  ",\"moving\":" + (moving ? "true" : "false") +
+                                                  ",\"sweeping\":" + (sweeping ? "true" : "false") + "}";
+                               return status;
+                           });
+
+        ESP_LOGI(TAG, "舵机MCP工具注册完成");
+    }
+
+public:
+    SG90ServoVoiceBoard() 
+        : boot_button_(BOOT_BUTTON_GPIO)
+        , touch_button_(TOUCH_BUTTON_GPIO)
+        , asr_button_(ASR_BUTTON_GPIO)
+        , servo_controller_(nullptr) {
+        
+        InitializeDisplayI2c();
+        InitializeSsd1306Display();
+        InitializeButtons();
+        InitializeServoController();
+    }
+
+    virtual ~SG90ServoVoiceBoard() {
+        if (servo_controller_) {
+            delete servo_controller_;
+        }
+    }
+
+    virtual AudioCodec* GetAudioCodec() override {
+#ifdef AUDIO_I2S_METHOD_SIMPLEX
+        static NoAudioCodecSimplex audio_codec(AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,
+            AUDIO_I2S_SPK_GPIO_BCLK, AUDIO_I2S_SPK_GPIO_LRCK, AUDIO_I2S_SPK_GPIO_DOUT, 
+            AUDIO_I2S_MIC_GPIO_SCK, AUDIO_I2S_MIC_GPIO_WS, AUDIO_I2S_MIC_GPIO_DIN);
+#else
+        static NoAudioCodecDuplex audio_codec(AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,
+            AUDIO_I2S_GPIO_BCLK, AUDIO_I2S_GPIO_WS, AUDIO_I2S_GPIO_DOUT, AUDIO_I2S_GPIO_DIN);
+#endif
+        return &audio_codec;
+    }
+
+    virtual Display* GetDisplay() override {
+        return display_;
+    }
+};
+
+DECLARE_BOARD(SG90ServoVoiceBoard);


### PR DESCRIPTION
- 在 CMakeLists.txt 和 Kconfig.projbuild 中添加 SG90 舵机语音控制板的配置选项
- 添加了完整的 SG90 舵机控制板代码实现，包括舵机控制、语音指令处理等功能
- 提供了舵机角度控制、旋转、扫描、停止等 MCP 工具接口
- 包含详细的硬件接线说明和编译烧录指南