### PR TITLE
fix: resolve some audio issues on esp-hi

### DIFF
--- a/main/audio/audio_service.cc
+++ b/main/audio/audio_service.cc
@@ -540,6 +540,12 @@ void AudioService::SetCallbacks(AudioServiceCallbacks& callbacks) {
 }
 
 void AudioService::PlaySound(const std::string_view& ogg) {
+    if (!codec_->output_enabled()) {
+        esp_timer_stop(audio_power_timer_);
+        esp_timer_start_periodic(audio_power_timer_, AUDIO_POWER_CHECK_INTERVAL_MS * 1000);
+        codec_->EnableOutput(true);
+    }
+
     const uint8_t* buf = reinterpret_cast<const uint8_t*>(ogg.data());
     size_t size = ogg.size();
     size_t offset = 0;

--- a/main/boards/esp-hi/adc_pdm_audio_codec.cc
+++ b/main/boards/esp-hi/adc_pdm_audio_codec.cc
@@ -141,8 +141,7 @@ void AdcPdmAudioCodec::EnableInput(bool enable) {
         };
         ESP_ERROR_CHECK(esp_codec_dev_open(input_dev_, &fs));
     } else {
-        // ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
-        return;
+        ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
     }
     AudioCodec::EnableInput(enable);
 }

--- a/main/boards/esp-hi/emoji_display.cc
+++ b/main/boards/esp-hi/emoji_display.cc
@@ -3,6 +3,7 @@
 #include <esp_log.h>
 #include "mmap_generate_emoji.h"
 #include "emoji_display.h"
+#include "assets/lang_config.h"
 
 #include <esp_lcd_panel_io.h>
 #include <freertos/FreeRTOS.h>
@@ -146,9 +147,9 @@ void EmojiWidget::SetEmotion(const char* emotion)
 void EmojiWidget::SetStatus(const char* status)
 {
     if (player_) {
-        if (strcmp(status, "聆听中...") == 0) {
+        if (strcmp(status, Lang::Strings::LISTENING) == 0) {
             player_->StartPlayer(MMAP_EMOJI_ASKING_AAF, true, 15);
-        } else if (strcmp(status, "待命") == 0) {
+        } else if (strcmp(status, Lang::Strings::STANDBY) == 0) {
             player_->StartPlayer(MMAP_EMOJI_WAKE_AAF, true, 15);
         }
     }

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -33,7 +33,7 @@ dependencies:
   espressif/esp_io_expander_tca95xx_16bit: ^2.0.0
   espressif2022/image_player: ==1.1.0~1
   espressif2022/esp_emote_gfx: ^1.0.0
-  espressif/adc_mic: ^0.2.0
+  espressif/adc_mic: ^0.2.1
   espressif/esp_mmap_assets: '>=1.2'
   txp666/otto-emoji-gif-component: ~1.0.2
   espressif/adc_battery_estimation: ^0.2.0


### PR DESCRIPTION
- 修复 https://github.com/78/xiaozhi-esp32/pull/984 `esp_codec_dev_close()` 后 crash 的问题。
- 修复在选择其他语言时，屏幕表情不能正常切换的问题。
- 缓解 esp-hi 的扬声器底噪。