### PR TITLE
Fix build error with esp_emote_gfx

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -32,7 +32,7 @@ dependencies:
   esp_lvgl_port: ~2.6.0
   espressif/esp_io_expander_tca95xx_16bit: ^2.0.0
   espressif2022/image_player: ==1.1.0~1
-  espressif2022/esp_emote_gfx: ^1.0.0
+  espressif2022/esp_emote_gfx: ==1.0.0~2
   espressif/adc_mic: ^0.2.1
   espressif/esp_mmap_assets: '>=1.2'
   txp666/otto-emoji-gif-component: ~1.0.2


### PR DESCRIPTION
@78 Fix build error of this https://github.com/78/xiaozhi-esp32/pull/1157#issuecomment-3251769645

https://components.espressif.com/components/espressif2022/esp_emote_gfx/versions/1.0.0~1/versions?language=

<img width="1303" height="663" alt="Screenshot 2025-09-04 at 2 45 09 PM" src="https://github.com/user-attachments/assets/8402bc1b-9941-4bf2-9a27-f07f8da10dad" />

