### PR TITLE
fix: ESP-HI audio sampling problem

### DIFF
--- a/main/boards/esp-hi/adc_pdm_audio_codec.h
+++ b/main/boards/esp-hi/adc_pdm_audio_codec.h
@@ -5,12 +5,20 @@
 
 #include <esp_codec_dev.h>
 #include <esp_codec_dev_defaults.h>
+#include <esp_timer.h>
 
 class AdcPdmAudioCodec : public AudioCodec {
 private:
     esp_codec_dev_handle_t output_dev_ = nullptr;
     esp_codec_dev_handle_t input_dev_ = nullptr;
     gpio_num_t pa_ctrl_pin_ = GPIO_NUM_NC;
+
+    // 定时器相关成员变量
+    esp_timer_handle_t output_timer_ = nullptr;
+    static constexpr uint64_t TIMER_TIMEOUT_US = 120000; // 120ms = 120000us
+
+    // 定时器回调函数
+    static void OutputTimerCallback(void* arg);
 
     virtual int Read(int16_t* dest, int samples) override;
     virtual int Write(const int16_t* data, int samples) override;

--- a/main/boards/esp-hi/config.h
+++ b/main/boards/esp-hi/config.h
@@ -6,6 +6,9 @@
 #define AUDIO_INPUT_SAMPLE_RATE  16000
 #define AUDIO_OUTPUT_SAMPLE_RATE 24000
 
+// 配置PDM上采样fs参数（取值范围<=480）。部分设备在441时表现更稳定
+#define AUDIO_PDM_UPSAMPLE_FS    441
+
 #define AUDIO_ADC_MIC_CHANNEL       2
 #define AUDIO_PDM_SPEAK_P_GPIO      GPIO_NUM_6
 #define AUDIO_PDM_SPEAK_N_GPIO      GPIO_NUM_7

--- a/main/boards/esp-hi/config.json
+++ b/main/boards/esp-hi/config.json
@@ -25,7 +25,6 @@
                 "CONFIG_LWIP_TCPIP_TASK_STACK_SIZE=2048",
                 "CONFIG_MBEDTLS_DYNAMIC_FREE_CONFIG_DATA=y",
                 "CONFIG_NEWLIB_NANO_FORMAT=y",
-                "CONFIG_MMAP_FILE_NAME_LENGTH=25",
                 "CONFIG_ESP_CONSOLE_NONE=y",
                 "CONFIG_USE_ESP_WAKE_WORD=y",
                 "CONFIG_COMPILER_OPTIMIZATION_SIZE=y"

--- a/main/boards/esp-hi/emoji_display.cc
+++ b/main/boards/esp-hi/emoji_display.cc
@@ -53,6 +53,8 @@ EmojiPlayer::EmojiPlayer(esp_lcd_panel_handle_t panel, esp_lcd_panel_io_handle_t
         .task = ANIM_PLAYER_INIT_CONFIG()
     };
 
+    player_cfg.task.task_priority = 1;
+    player_cfg.task.task_stack = 4096;
     player_handle_ = anim_player_init(&player_cfg);
 
     const esp_lcd_panel_io_callbacks_t cbs = {

--- a/main/boards/esp-hi/emoji_display.h
+++ b/main/boards/esp-hi/emoji_display.h
@@ -37,6 +37,8 @@ public:
 
     virtual void SetEmotion(const char* emotion) override;
     virtual void SetStatus(const char* status) override;
+    virtual void SetChatMessage(const char* role, const char* content) override {}
+
     anim::EmojiPlayer* GetPlayer()
     {
         return player_.get();

--- a/main/boards/esp-hi/esp_hi.cc
+++ b/main/boards/esp-hi/esp_hi.cc
@@ -397,11 +397,6 @@ public:
         InitializeSpi();
         InitializeLcdDisplay();
         InitializeTools();
-
-        DeviceStateEventManager::GetInstance().RegisterStateChangeCallback([this](DeviceState previous_state, DeviceState current_state) {
-            ESP_LOGD(TAG, "Device state changed from %d to %d", previous_state, current_state);
-            this->GetAudioCodec()->EnableOutput(current_state == kDeviceStateSpeaking);
-        });
     }
 
     virtual AudioCodec* GetAudioCodec() override


### PR DESCRIPTION
This pull request introduces enhancements to the `AdcPdmAudioCodec` class for improved audio output control and stability, particularly by integrating a timer-based mechanism to automatically disable output after a period of inactivity. Additionally, it adds configuration flexibility for PDM upsampling, and includes some minor improvements to display and configuration files.

**Audio output control and stability improvements:**

* Added an `esp_timer`-based mechanism to `AdcPdmAudioCodec` that starts a timer when audio output is enabled or data is written; the timer disables output after a 120ms timeout to prevent unwanted continuous audio output. Timer is properly created, started, stopped, and deleted as needed. (`adc_pdm_audio_codec.cc`, `adc_pdm_audio_codec.h`) [[1]](diffhunk://#diff-7b74cb910baa7ba9cb5378e6bcbf47c1af67dad78da659a021357d50bb1bfb38R117-R137) [[2]](diffhunk://#diff-7b74cb910baa7ba9cb5378e6bcbf47c1af67dad78da659a021357d50bb1bfb38R183-R203) [[3]](diffhunk://#diff-7b74cb910baa7ba9cb5378e6bcbf47c1af67dad78da659a021357d50bb1bfb38R221-R225) [[4]](diffhunk://#diff-7b74cb910baa7ba9cb5378e6bcbf47c1af67dad78da659a021357d50bb1bfb38L198-R249) [[5]](diffhunk://#diff-0801b6b2fa65bf5a9d464c12ebed3fab2883d8d70df91f40a63c7733967fc631R8-R22)
* Ensured that PDM TX clock's `up_sample_fs` parameter is always set according to board configuration, overriding third-party library defaults, for consistent audio performance. (`adc_pdm_audio_codec.cc`) [[1]](diffhunk://#diff-7b74cb910baa7ba9cb5378e6bcbf47c1af67dad78da659a021357d50bb1bfb38L74-R76) [[2]](diffhunk://#diff-7b74cb910baa7ba9cb5378e6bcbf47c1af67dad78da659a021357d50bb1bfb38R183-R203)

**Configuration and flexibility:**

* Introduced `AUDIO_PDM_UPSAMPLE_FS` macro in `config.h` to allow easy adjustment of the PDM upsampling factor, improving device compatibility and audio quality. (`config.h`)
* Included `config.h` in `adc_pdm_audio_codec.cc` to access new configuration macros.

**Minor improvements:**

* Set explicit task priority and stack size for the emoji animation player to ensure reliable operation. (`emoji_display.cc`)
* Added a stub override for `SetChatMessage` in `EmojiWidget` for interface completeness. (`emoji_display.h`)
* Removed an unused configuration option from `config.json` for cleanup. (`config.json`)
* Removed a device state change callback in `esp_hi.cc` that previously toggled audio output, likely superseded by the new timer-based approach. (`esp_hi.cc`)