### PR TITLE
fix: Correct the touch offset of lichuang_S3_dev

### DIFF
--- a/main/boards/lichuang-dev/lichuang_dev_board.cc
+++ b/main/boards/lichuang-dev/lichuang_dev_board.cc
@@ -160,8 +160,8 @@ private:
     {
         esp_lcd_touch_handle_t tp;
         esp_lcd_touch_config_t tp_cfg = {
-            .x_max = DISPLAY_WIDTH,
-            .y_max = DISPLAY_HEIGHT,
+            .x_max = DISPLAY_HEIGHT,
+            .y_max = DISPLAY_WIDTH,
             .rst_gpio_num = GPIO_NUM_NC, // Shared with LCD reset
             .int_gpio_num = GPIO_NUM_NC, 
             .levels = {


### PR DESCRIPTION
Corrected the misconfigured touchscreen parameters of lichuang_S3_dev, which caused touch offset.
            .x_max = DISPLAY_WIDTH,
            .y_max = DISPLAY_HEIGHT,
This parameter conflicts with the configuration   (.swap_xy = 1) .
fix to：
            .x_max = DISPLAY_HEIGHT,
            .y_max = DISPLAY_WIDTH,

