### PR TITLE
fix emote display errors

### DIFF
--- a/main/boards/esp-box-3/esp_box3_board.cc
+++ b/main/boards/esp-box-3/esp_box3_board.cc
@@ -129,10 +129,10 @@ private:
         esp_lcd_panel_disp_on_off(panel, true);
 
 #if CONFIG_USE_EMOTE_MESSAGE_STYLE
-    display_ = new emote::EmoteDisplay(panel, panel_io, DISPLAY_WIDTH, DISPLAY_HEIGHT);
+        display_ = new emote::EmoteDisplay(panel, panel_io, DISPLAY_WIDTH, DISPLAY_HEIGHT);
 #else
-    display_ = new SpiLcdDisplay(panel_io, panel,
-        DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
+        display_ = new SpiLcdDisplay(panel_io, panel,
+            DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
 #endif
     }
 

--- a/main/display/emote_display.cc
+++ b/main/display/emote_display.cc
@@ -236,6 +236,7 @@ static void SetupUI(const gfx_handle_t engine_handle, EmoteDisplay* const displa
     g_obj_anim_eye = gfx_anim_create(engine_handle);
     gfx_obj_align(g_obj_anim_eye, GFX_ALIGN_LEFT_MID, 10, 30);
     gfx_anim_set_auto_mirror(g_obj_anim_eye, true);
+    gfx_obj_set_visible(g_obj_anim_eye, false);
 
     g_obj_label_toast = gfx_label_create(engine_handle);
     gfx_obj_align(g_obj_label_toast, GFX_ALIGN_TOP_MID, 0, 20);
@@ -290,8 +291,9 @@ EmoteEngine::EmoteEngine(const esp_lcd_panel_handle_t panel, const esp_lcd_panel
     InitializeGraphics(panel, &engine_handle_, width, height);
 
     if (display) {
-        DisplayLockGuard lock(display);
+        gfx_emote_lock(engine_handle_);
         SetupUI(engine_handle_, display);
+        gfx_emote_unlock(engine_handle_);
     }
 
     RegisterCallbacks(panel_io, engine_handle_);
@@ -322,6 +324,7 @@ void EmoteEngine::SetEyes(const std::string &emoji_name, const bool repeat, cons
         DisplayLockGuard lock(display);
         gfx_anim_set_src(g_obj_anim_eye, emoji_data.data, emoji_data.size);
         gfx_anim_set_segment(g_obj_anim_eye, 0, 0xFFFF, fps, repeat);
+        gfx_obj_set_visible(g_obj_anim_eye, true);
         gfx_anim_start(g_obj_anim_eye);
     } else {
         ESP_LOGW(TAG, "SetEyes: No emoji data found for %s", emoji_name.c_str());


### PR DESCRIPTION
This pull request improves the visibility management and thread safety of the eye animation object in the emote display system. The main changes ensure that the eye animation is properly hidden or shown as needed and that UI setup operations are safely guarded with appropriate locking.

**UI Visibility Management:**

* The eye animation object (`g_obj_anim_eye`) is now explicitly hidden during UI setup and shown only when an eye animation is started, preventing it from appearing unintentionally. [[1]](diffhunk://#diff-12b2e1ba171f57081f73691b13a6c4fb9af7ce6ab85de61fa4ee69244c428442R239) [[2]](diffhunk://#diff-12b2e1ba171f57081f73691b13a6c4fb9af7ce6ab85de61fa4ee69244c428442R327)

**Thread Safety and Locking:**

* The UI setup process now uses `gfx_emote_lock` and `gfx_emote_unlock` for thread safety instead of the previous `DisplayLockGuard`, ensuring consistent locking behavior during UI initialization.