### PR TITLE
Add SetInputGain(float gain) to AudioCodec

### DIFF
--- a/main/audio/audio_codec.cc
+++ b/main/audio/audio_codec.cc
@@ -55,6 +55,11 @@ void AudioCodec::SetOutputVolume(int volume) {
     settings.SetInt("output_volume", output_volume_);
 }
 
+void AudioCodec::SetInputGain(float gain) {
+    input_gain_ = gain;
+    ESP_LOGI(TAG, "Set input gain to %.1f", input_gain_);
+}
+
 void AudioCodec::EnableInput(bool enable) {
     if (enable == input_enabled_) {
         return;

--- a/main/audio/audio_codec.h
+++ b/main/audio/audio_codec.h
@@ -13,7 +13,6 @@
 
 #define AUDIO_CODEC_DMA_DESC_NUM 6
 #define AUDIO_CODEC_DMA_FRAME_NUM 240
-#define AUDIO_CODEC_DEFAULT_MIC_GAIN 30.0
 
 class AudioCodec {
 public:
@@ -21,6 +20,7 @@ public:
     virtual ~AudioCodec();
     
     virtual void SetOutputVolume(int volume);
+    virtual void SetInputGain(float gain);
     virtual void EnableInput(bool enable);
     virtual void EnableOutput(bool enable);
 
@@ -35,6 +35,7 @@ public:
     inline int input_channels() const { return input_channels_; }
     inline int output_channels() const { return output_channels_; }
     inline int output_volume() const { return output_volume_; }
+    inline float input_gain() const { return input_gain_; }
     inline bool input_enabled() const { return input_enabled_; }
     inline bool output_enabled() const { return output_enabled_; }
 
@@ -51,6 +52,7 @@ protected:
     int input_channels_ = 1;
     int output_channels_ = 1;
     int output_volume_ = 70;
+    float input_gain_ = 0.0;
 
     virtual int Read(int16_t* dest, int samples) = 0;
     virtual int Write(const int16_t* data, int samples) = 0;

--- a/main/audio/codecs/box_audio_codec.cc
+++ b/main/audio/codecs/box_audio_codec.cc
@@ -14,6 +14,7 @@ BoxAudioCodec::BoxAudioCodec(void* i2c_master_handle, int input_sample_rate, int
     input_channels_ = input_reference_ ? 2 : 1; // 输入通道数
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
+    input_gain_ = 30;
 
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
 
@@ -200,7 +201,7 @@ void BoxAudioCodec::EnableInput(bool enable) {
             fs.channel_mask |= ESP_CODEC_DEV_MAKE_CHANNEL_MASK(1);
         }
         ESP_ERROR_CHECK(esp_codec_dev_open(input_dev_, &fs));
-        ESP_ERROR_CHECK(esp_codec_dev_set_in_channel_gain(input_dev_, ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), AUDIO_CODEC_DEFAULT_MIC_GAIN));
+        ESP_ERROR_CHECK(esp_codec_dev_set_in_channel_gain(input_dev_, ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), input_gain_));
     } else {
         ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
     }

--- a/main/audio/codecs/es8311_audio_codec.cc
+++ b/main/audio/codecs/es8311_audio_codec.cc
@@ -14,6 +14,7 @@ Es8311AudioCodec::Es8311AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port,
     output_sample_rate_ = output_sample_rate;
     pa_pin_ = pa_pin;
     pa_inverted_ = pa_inverted;
+    input_gain_ = 30;
 
     assert(input_sample_rate_ == output_sample_rate_);
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
@@ -81,7 +82,7 @@ void Es8311AudioCodec::UpdateDeviceState() {
             .mclk_multiple = 0,
         };
         ESP_ERROR_CHECK(esp_codec_dev_open(dev_, &fs));
-        ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(dev_, AUDIO_CODEC_DEFAULT_MIC_GAIN));
+        ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(dev_, input_gain_));
         ESP_ERROR_CHECK(esp_codec_dev_set_out_vol(dev_, output_volume_));
     } else if (!input_enabled_ && !output_enabled_ && dev_ != nullptr) {
         esp_codec_dev_close(dev_);

--- a/main/audio/codecs/es8374_audio_codec.cc
+++ b/main/audio/codecs/es8374_audio_codec.cc
@@ -12,6 +12,8 @@ Es8374AudioCodec::Es8374AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port,
     input_channels_ = 1; // 输入通道数
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
+    input_gain_ = 30;
+
     pa_pin_ = pa_pin;
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
 
@@ -146,7 +148,7 @@ void Es8374AudioCodec::EnableInput(bool enable) {
             .mclk_multiple = 0,
         };
         ESP_ERROR_CHECK(esp_codec_dev_open(input_dev_, &fs));
-        ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(input_dev_, AUDIO_CODEC_DEFAULT_MIC_GAIN));
+        ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(input_dev_, input_gain_));
     } else {
         ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
     }

--- a/main/audio/codecs/es8388_audio_codec.cc
+++ b/main/audio/codecs/es8388_audio_codec.cc
@@ -12,6 +12,8 @@ Es8388AudioCodec::Es8388AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port,
     input_channels_ = input_reference_ ? 2 : 1; // 输入通道数
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
+    input_gain_ = 24;
+
     pa_pin_ = pa_pin;
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
 
@@ -158,7 +160,7 @@ void Es8388AudioCodec::EnableInput(bool enable) {
             uint8_t gain = (11 << 4) + 0;
             ctrl_if_->write_reg(ctrl_if_, 0x09, 1, &gain, 1);
         }else{
-            ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(input_dev_, 24.0));
+            ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(input_dev_, input_gain_));
         }
     } else {
         ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));

--- a/main/audio/codecs/es8389_audio_codec.cc
+++ b/main/audio/codecs/es8389_audio_codec.cc
@@ -12,6 +12,7 @@ Es8389AudioCodec::Es8389AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port,
     input_channels_ = 1; // 输入通道数
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
+    input_gain_ = 40;
     pa_pin_ = pa_pin;
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
 
@@ -153,7 +154,7 @@ void Es8389AudioCodec::EnableInput(bool enable) {
             .mclk_multiple = 0,
         };
         ESP_ERROR_CHECK(esp_codec_dev_open(input_dev_, &fs));
-        ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(input_dev_, 40.0));
+        ESP_ERROR_CHECK(esp_codec_dev_set_in_gain(input_dev_, input_gain_));
     } else {
         ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
     }

--- a/main/audio/codecs/no_audio_codec.cc
+++ b/main/audio/codecs/no_audio_codec.cc
@@ -214,7 +214,53 @@ NoAudioCodecSimplex::NoAudioCodecSimplex(int input_sample_rate, int output_sampl
     ESP_LOGI(TAG, "Simplex channels created");
 }
 
-NoAudioCodecSimplexPdm::NoAudioCodecSimplexPdm(int input_sample_rate, int output_sample_rate, gpio_num_t spk_bclk, gpio_num_t spk_ws, gpio_num_t spk_dout, i2s_std_slot_mask_t spk_slot_mask,gpio_num_t mic_sck, gpio_num_t mic_din) {
+int NoAudioCodec::Write(const int16_t* data, int samples) {
+    std::lock_guard<std::mutex> lock(data_if_mutex_);
+    std::vector<int32_t> buffer(samples);
+
+    // output_volume_: 0-100
+    // volume_factor_: 0-65536
+    int32_t volume_factor = pow(double(output_volume_) / 100.0, 2) * 65536;
+    for (int i = 0; i < samples; i++) {
+        int64_t temp = int64_t(data[i]) * volume_factor; // 使用 int64_t 进行乘法运算
+        if (temp > INT32_MAX) {
+            buffer[i] = INT32_MAX;
+        } else if (temp < INT32_MIN) {
+            buffer[i] = INT32_MIN;
+        } else {
+            buffer[i] = static_cast<int32_t>(temp);
+        }
+    }
+
+    size_t bytes_written;
+    ESP_ERROR_CHECK(i2s_channel_write(tx_handle_, buffer.data(), samples * sizeof(int32_t), &bytes_written, portMAX_DELAY));
+    return bytes_written / sizeof(int32_t);
+}
+
+int NoAudioCodec::Read(int16_t* dest, int samples) {
+    size_t bytes_read;
+
+    std::vector<int32_t> bit32_buffer(samples);
+    if (i2s_channel_read(rx_handle_, bit32_buffer.data(), samples * sizeof(int32_t), &bytes_read, portMAX_DELAY) != ESP_OK) {
+        ESP_LOGE(TAG, "Read Failed!");
+        return 0;
+    }
+
+    samples = bytes_read / sizeof(int32_t);
+    for (int i = 0; i < samples; i++) {
+        int32_t value = bit32_buffer[i] >> 12;
+        dest[i] = (value > INT16_MAX) ? INT16_MAX : (value < -INT16_MAX) ? -INT16_MAX : (int16_t)value;
+    }
+    return samples;
+}
+
+// Delegating constructor: calls the main constructor with default slot mask
+NoAudioCodecSimplexPdm::NoAudioCodecSimplexPdm(int input_sample_rate, int output_sample_rate, gpio_num_t spk_bclk, gpio_num_t spk_ws, gpio_num_t spk_dout, gpio_num_t mic_sck, gpio_num_t mic_din) 
+    : NoAudioCodecSimplexPdm(input_sample_rate, output_sample_rate, spk_bclk, spk_ws, spk_dout, I2S_STD_SLOT_LEFT, mic_sck, mic_din) {
+    // All initialization is handled by the delegated constructor
+}
+
+NoAudioCodecSimplexPdm::NoAudioCodecSimplexPdm(int input_sample_rate, int output_sample_rate, gpio_num_t spk_bclk, gpio_num_t spk_ws, gpio_num_t spk_dout, i2s_std_slot_mask_t spk_slot_mask, gpio_num_t mic_sck, gpio_num_t mic_din) {
     duplex_ = false;
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
@@ -292,110 +338,6 @@ NoAudioCodecSimplexPdm::NoAudioCodecSimplexPdm(int input_sample_rate, int output
     ESP_LOGI(TAG, "Simplex channels created");
 }
 
-NoAudioCodecSimplexPdm::NoAudioCodecSimplexPdm(int input_sample_rate, int output_sample_rate, gpio_num_t spk_bclk, gpio_num_t spk_ws, gpio_num_t spk_dout, gpio_num_t mic_sck, gpio_num_t mic_din) {
-    duplex_ = false;
-    input_sample_rate_ = input_sample_rate;
-    output_sample_rate_ = output_sample_rate;
-
-    // Create a new channel for speaker
-    i2s_chan_config_t tx_chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG((i2s_port_t)1, I2S_ROLE_MASTER);
-    tx_chan_cfg.dma_desc_num = AUDIO_CODEC_DMA_DESC_NUM;
-    tx_chan_cfg.dma_frame_num = AUDIO_CODEC_DMA_FRAME_NUM;
-    tx_chan_cfg.auto_clear_after_cb = true;
-    tx_chan_cfg.auto_clear_before_cb = false;
-    tx_chan_cfg.intr_priority = 0;
-    ESP_ERROR_CHECK(i2s_new_channel(&tx_chan_cfg, &tx_handle_, NULL));
-
-
-    i2s_std_config_t tx_std_cfg = {
-        .clk_cfg = {
-            .sample_rate_hz = (uint32_t)output_sample_rate_,
-            .clk_src = I2S_CLK_SRC_DEFAULT,
-            .mclk_multiple = I2S_MCLK_MULTIPLE_256,
-			#ifdef   I2S_HW_VERSION_2
-				.ext_clk_freq_hz = 0,
-			#endif
-
-        },
-        .slot_cfg = I2S_STD_MSB_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_32BIT, I2S_SLOT_MODE_MONO),
-        .gpio_cfg = {
-            .mclk = I2S_GPIO_UNUSED,
-            .bclk = spk_bclk,
-            .ws = spk_ws,
-            .dout = spk_dout,
-            .din = I2S_GPIO_UNUSED,
-            .invert_flags = {
-                .mclk_inv = false,
-                .bclk_inv = false,
-                .ws_inv   = false,
-            },
-        },
-    };
-    ESP_ERROR_CHECK(i2s_channel_init_std_mode(tx_handle_, &tx_std_cfg));
-#if SOC_I2S_SUPPORTS_PDM_RX
-    // Create a new channel for MIC in PDM mode
-    i2s_chan_config_t rx_chan_cfg = I2S_CHANNEL_DEFAULT_CONFIG((i2s_port_t)0, I2S_ROLE_MASTER);
-    ESP_ERROR_CHECK(i2s_new_channel(&rx_chan_cfg, NULL, &rx_handle_));
-    i2s_pdm_rx_config_t pdm_rx_cfg = {
-        .clk_cfg = I2S_PDM_RX_CLK_DEFAULT_CONFIG((uint32_t)input_sample_rate_),
-        /* The data bit-width of PDM mode is fixed to 16 */
-        .slot_cfg = I2S_PDM_RX_SLOT_DEFAULT_CONFIG(I2S_DATA_BIT_WIDTH_16BIT, I2S_SLOT_MODE_MONO),
-        .gpio_cfg = {
-            .clk = mic_sck,
-            .din = mic_din,
-
-            .invert_flags = {
-                .clk_inv = false,
-            },
-        },
-    };
-    ESP_ERROR_CHECK(i2s_channel_init_pdm_rx_mode(rx_handle_, &pdm_rx_cfg));
-#else
-    ESP_LOGE(TAG, "PDM is not supported");
-#endif
-    ESP_LOGI(TAG, "Simplex channels created");
-}
-
-int NoAudioCodec::Write(const int16_t* data, int samples) {
-    std::lock_guard<std::mutex> lock(data_if_mutex_);
-    std::vector<int32_t> buffer(samples);
-
-    // output_volume_: 0-100
-    // volume_factor_: 0-65536
-    int32_t volume_factor = pow(double(output_volume_) / 100.0, 2) * 65536;
-    for (int i = 0; i < samples; i++) {
-        int64_t temp = int64_t(data[i]) * volume_factor; // 使用 int64_t 进行乘法运算
-        if (temp > INT32_MAX) {
-            buffer[i] = INT32_MAX;
-        } else if (temp < INT32_MIN) {
-            buffer[i] = INT32_MIN;
-        } else {
-            buffer[i] = static_cast<int32_t>(temp);
-        }
-    }
-
-    size_t bytes_written;
-    ESP_ERROR_CHECK(i2s_channel_write(tx_handle_, buffer.data(), samples * sizeof(int32_t), &bytes_written, portMAX_DELAY));
-    return bytes_written / sizeof(int32_t);
-}
-
-int NoAudioCodec::Read(int16_t* dest, int samples) {
-    size_t bytes_read;
-
-    std::vector<int32_t> bit32_buffer(samples);
-    if (i2s_channel_read(rx_handle_, bit32_buffer.data(), samples * sizeof(int32_t), &bytes_read, portMAX_DELAY) != ESP_OK) {
-        ESP_LOGE(TAG, "Read Failed!");
-        return 0;
-    }
-
-    samples = bytes_read / sizeof(int32_t);
-    for (int i = 0; i < samples; i++) {
-        int32_t value = bit32_buffer[i] >> 12;
-        dest[i] = (value > INT16_MAX) ? INT16_MAX : (value < -INT16_MAX) ? -INT16_MAX : (int16_t)value;
-    }
-    return samples;
-}
-
 int NoAudioCodecSimplexPdm::Read(int16_t* dest, int samples) {
     size_t bytes_read;
 
@@ -405,6 +347,13 @@ int NoAudioCodecSimplexPdm::Read(int16_t* dest, int samples) {
         return 0;
     }
 
-    // 计算实际读取的样本数
-    return bytes_read / sizeof(int16_t);
+    samples = bytes_read / sizeof(int16_t);
+    if (input_gain_ > 0) {
+        int gain_factor = (int)input_gain_;
+        for (int i = 0; i < samples; i++) {
+            int32_t amplified = dest[i] * gain_factor;
+            dest[i] = (amplified > INT16_MAX) ? INT16_MAX : (amplified < -INT16_MAX) ? -INT16_MAX : (int16_t)amplified;
+        }
+    }
+    return samples;
 }

--- a/main/boards/m5stack-core-s3/cores3_audio_codec.cc
+++ b/main/boards/m5stack-core-s3/cores3_audio_codec.cc
@@ -14,6 +14,7 @@ CoreS3AudioCodec::CoreS3AudioCodec(void* i2c_master_handle, int input_sample_rat
     input_channels_ = input_reference_ ? 2 : 1; // 输入通道数
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
+    input_gain_ = 30;
 
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
 
@@ -200,7 +201,7 @@ void CoreS3AudioCodec::EnableInput(bool enable) {
             fs.channel_mask |= ESP_CODEC_DEV_MAKE_CHANNEL_MASK(1);
         }
         ESP_ERROR_CHECK(esp_codec_dev_open(input_dev_, &fs));
-        ESP_ERROR_CHECK(esp_codec_dev_set_in_channel_gain(input_dev_, ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), AUDIO_CODEC_DEFAULT_MIC_GAIN));
+        ESP_ERROR_CHECK(esp_codec_dev_set_in_channel_gain(input_dev_, ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), input_gain_));
     } else {
         ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
     }

--- a/main/boards/m5stack-tab5/tab5_audio_codec.cc
+++ b/main/boards/m5stack-tab5/tab5_audio_codec.cc
@@ -14,6 +14,7 @@ Tab5AudioCodec::Tab5AudioCodec(void* i2c_master_handle, int input_sample_rate, i
     input_channels_ = input_reference_ ? 2 : 1; // 输入通道数
     input_sample_rate_ = input_sample_rate;
     output_sample_rate_ = output_sample_rate;
+    input_gain_ = 30;
 
     CreateDuplexChannels(mclk, bclk, ws, dout, din);
 
@@ -199,7 +200,7 @@ void Tab5AudioCodec::EnableInput(bool enable) {
             fs.channel_mask |= ESP_CODEC_DEV_MAKE_CHANNEL_MASK(1);
         }
         ESP_ERROR_CHECK(esp_codec_dev_open(input_dev_, &fs));
-        ESP_ERROR_CHECK(esp_codec_dev_set_in_channel_gain(input_dev_, ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), AUDIO_CODEC_DEFAULT_MIC_GAIN));
+        ESP_ERROR_CHECK(esp_codec_dev_set_in_channel_gain(input_dev_, ESP_CODEC_DEV_MAKE_CHANNEL_MASK(0), input_gain_));
     } else {
         ESP_ERROR_CHECK(esp_codec_dev_close(input_dev_));
     }


### PR DESCRIPTION
This pull request introduces a unified and configurable input gain system for all audio codec classes, replacing hardcoded microphone gain values. It adds an `input_gain_` member to the base `AudioCodec` class, provides a setter method, and ensures that each codec uses this member for setting input gain. Additionally, it improves the `NoAudioCodec` and `NoAudioCodecSimplexPdm` classes by implementing input gain amplification in software. These changes make audio input gain more flexible and easier to manage across different hardware implementations.

**Input Gain Refactor and Configuration**

* Added `input_gain_` member variable and corresponding getter/setter (`SetInputGain`, `input_gain`) to the base `AudioCodec` class, allowing input gain to be set and queried in a unified way. (`main/audio/audio_codec.h`, `main/audio/audio_codec.cc`) [[1]](diffhunk://#diff-7ea5601a216dc96dd8dc9872b7ddf197d694db069f45b32048736fb3786c211bL16-R23) [[2]](diffhunk://#diff-7ea5601a216dc96dd8dc9872b7ddf197d694db069f45b32048736fb3786c211bR38) [[3]](diffhunk://#diff-7ea5601a216dc96dd8dc9872b7ddf197d694db069f45b32048736fb3786c211bR55) [[4]](diffhunk://#diff-aaaf025b6434a136515f5971d781db2e397c076628984c7c40e2f03ff4303170R58-R62)
* Updated all derived codec constructors to initialize `input_gain_` with appropriate default values for each hardware type. (`main/audio/codecs/box_audio_codec.cc`, `main/audio/codecs/es8311_audio_codec.cc`, `main/audio/codecs/es8374_audio_codec.cc`, `main/audio/codecs/es8388_audio_codec.cc`, `main/audio/codecs/es8389_audio_codec.cc`, `main/boards/m5stack-core-s3/cores3_audio_codec.cc`, `main/boards/m5stack-tab5/tab5_audio_codec.cc`) [[1]](diffhunk://#diff-2964a22c13312dd8611aba9669b908270aec78814907154dc0de05da1f59e30bR17) [[2]](diffhunk://#diff-d3ff5691ea724689c4f6f2d4eba4f4266106352b70d1dcd4d7233e55d69a4355R17) [[3]](diffhunk://#diff-a5e21a75c10fe66c7749d167fb162db62d8c4c89cf65d7054d61bb5c56e0e26aR15-R16) [[4]](diffhunk://#diff-b22cbc0f81e1a57b5522b92267a31d6fffb2957290f6087e6afa0d7c06572027R15-R16) [[5]](diffhunk://#diff-1fdb511767950c8eb222d2d808cb71739b36beb34ed02d926048b64a6d0ab75dR15) [[6]](diffhunk://#diff-b733c5a04f479560f3b3f8eb2e58533a3f12408cdc3e852d764b70aa84be8c33R17) [[7]](diffhunk://#diff-dcc2d2fc6e326d5e0be61f7b7acf5739ec17b57c5c985b8dfc5b27f7c07de0bdR17)
* Modified all codec input enable methods to use the configurable `input_gain_` value instead of hardcoded or macro-defined gain values. (`main/audio/codecs/box_audio_codec.cc`, `main/audio/codecs/es8311_audio_codec.cc`, `main/audio/codecs/es8374_audio_codec.cc`, `main/audio/codecs/es8388_audio_codec.cc`, `main/audio/codecs/es8389_audio_codec.cc`, `main/boards/m5stack-core-s3/cores3_audio_codec.cc`, `main/boards/m5stack-tab5/tab5_audio_codec.cc`) [[1]](diffhunk://#diff-2964a22c13312dd8611aba9669b908270aec78814907154dc0de05da1f59e30bL203-R204) [[2]](diffhunk://#diff-d3ff5691ea724689c4f6f2d4eba4f4266106352b70d1dcd4d7233e55d69a4355L84-R85) [[3]](diffhunk://#diff-a5e21a75c10fe66c7749d167fb162db62d8c4c89cf65d7054d61bb5c56e0e26aL149-R151) [[4]](diffhunk://#diff-b22cbc0f81e1a57b5522b92267a31d6fffb2957290f6087e6afa0d7c06572027L161-R163) [[5]](diffhunk://#diff-1fdb511767950c8eb222d2d808cb71739b36beb34ed02d926048b64a6d0ab75dL156-R157) [[6]](diffhunk://#diff-b733c5a04f479560f3b3f8eb2e58533a3f12408cdc3e852d764b70aa84be8c33L203-R204) [[7]](diffhunk://#diff-dcc2d2fc6e326d5e0be61f7b7acf5739ec17b57c5c985b8dfc5b27f7c07de0bdL202-R203)

**NoAudioCodec Improvements**

* Implemented software-based input gain amplification in `NoAudioCodecSimplexPdm::Read`, scaling the input samples by `input_gain_` before returning them. (`main/audio/codecs/no_audio_codec.cc`)
* Refactored and moved the `Write` and `Read` implementations for `NoAudioCodec` to improve code organization and ensure correct volume and gain handling. (`main/audio/codecs/no_audio_codec.cc`) [[1]](diffhunk://#diff-0a500e60679a9b5425dc614437b6f1071281c4749bc29d1fcd657a8f6b35a4fbR217-R262) [[2]](diffhunk://#diff-0a500e60679a9b5425dc614437b6f1071281c4749bc29d1fcd657a8f6b35a4fbL295-L398)

These changes make the audio input gain handling more flexible, maintainable, and consistent across all supported codecs.