### PR TITLE
将太极派新款和旧款分离

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -638,7 +638,6 @@ config RECEIVE_CUSTOM_MESSAGE
 menu "TAIJIPAI_S3_CONFIG"
     depends on BOARD_TYPE_ESP32S3_Taiji_Pi
     choice I2S_TYPE_TAIJIPI_S3
-        depends on BOARD_TYPE_ESP32S3_Taiji_Pi
         prompt "taiji-pi-S3 I2S Type"
         default TAIJIPAI_I2S_TYPE_STD
         help

--- a/main/boards/taiji-pi-s3/config.json
+++ b/main/boards/taiji-pi-s3/config.json
@@ -9,7 +9,7 @@
             ]
         },
         {
-            "name": "taiji-pi-s3-new",
+            "name": "taiji-pi-s3-pdm",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=y",
                 "CONFIG_TAIJIPAI_I2S_TYPE_PDM=y"


### PR DESCRIPTION
由于原来的OAT升级会默认使用旧款的配置，导致升级后新款显示异常