### PR TITLE
Update the default wake-up word configuration for the ESP32-P4 chip

### DIFF
--- a/main/boards/waveshare-p4-nano/config.json
+++ b/main/boards/waveshare-p4-nano/config.json
@@ -5,7 +5,8 @@
             "name": "waveshare-p4-nano-10.1-a",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=y",
-                "CONFIG_LCD_TYPE_800_1280_10_1_INCH_A=y"
+                "CONFIG_LCD_TYPE_800_1280_10_1_INCH_A=y",
+                "CONFIG_USE_AFE_WAKE_WORD=y"
             ]
         }
     ]

--- a/main/boards/waveshare-p4-wifi6-touch-lcd-4b/config.json
+++ b/main/boards/waveshare-p4-wifi6-touch-lcd-4b/config.json
@@ -5,6 +5,7 @@
             "name": "waveshare-p4-wifi6-touch-lcd-4b",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_AFE_WAKE_WORD=y",
                 "CONFIG_USE_DEVICE_AEC=y"
             ]
         }

--- a/main/boards/waveshare-p4-wifi6-touch-lcd-7b/config.json
+++ b/main/boards/waveshare-p4-wifi6-touch-lcd-7b/config.json
@@ -5,6 +5,7 @@
             "name": "waveshare-p4-wifi6-touch-lcd-7b",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_AFE_WAKE_WORD=y",
                 "CONFIG_USE_DEVICE_AEC=y"
             ]
         }

--- a/main/boards/waveshare-p4-wifi6-touch-lcd-xc/config.json
+++ b/main/boards/waveshare-p4-wifi6-touch-lcd-xc/config.json
@@ -5,6 +5,7 @@
             "name": "waveshare-p4-wifi6-touch-lcd-xc-3.4c",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_AFE_WAKE_WORD=y",
                 "CONFIG_USE_DEVICE_AEC=y",
                 "CONFIG_LCD_TYPE_800_800_3_4_INCH=y"
             ]
@@ -13,6 +14,7 @@
             "name": "waveshare-p4-wifi6-touch-lcd-xc-4c",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_AFE_WAKE_WORD=y",
                 "CONFIG_USE_DEVICE_AEC=y",
                 "CONFIG_LCD_TYPE_720_720_4_INCH=y"
             ]


### PR DESCRIPTION
The wake-up word configuration has been missing. Now, it will be supplemented,tested.