### PR TITLE
[BugFix] upgrade image_player component to ^1.1.1

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -39,7 +39,7 @@ dependencies:
   lvgl/lvgl: ~9.3.0
   esp_lvgl_port: ~2.6.0
   espressif/esp_io_expander_tca95xx_16bit: ^2.0.0
-  espressif2022/image_player: ==1.1.0~1
+  espressif2022/image_player: ^1.1.1
   espressif2022/esp_emote_gfx: ^1.1.2
   espressif/adc_mic: ^0.2.1
   espressif/esp_mmap_assets: '>=1.2'


### PR DESCRIPTION
- Update espressif2022/image_player from ==1.1.0~1 to ^1.1.1
- Use caret (^) to allow compatible version updates