### PR TITLE
[BugFix]upgrade image_player component to ^1.1.1 and esp_emote_gfx to…

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -31,8 +31,8 @@ dependencies:
   lvgl/lvgl: ~9.3.0
   esp_lvgl_port: ~2.6.0
   espressif/esp_io_expander_tca95xx_16bit: ^2.0.0
-  espressif2022/image_player: ==1.1.0~1
-  espressif2022/esp_emote_gfx: ==1.0.0~2
+  espressif2022/image_player: ^1.1.1
+  espressif2022/esp_emote_gfx: ^1.0.2
   espressif/adc_mic: ^0.2.1
   espressif/esp_mmap_assets: '>=1.2'
   txp666/otto-emoji-gif-component: ~1.0.2


### PR DESCRIPTION
… ^1.0.2

- Update espressif2022/image_player from ==1.1.0~1 to ^1.1.1
- Update espressif2022/esp_emote_gfx from ==1.0.0~2 to ^1.0.2
- Use caret (^) to allow compatible version updates