### PR TITLE
Fix the touch initialization issue.

### DIFF
--- a/main/boards/waveshare-p4-wifi6-touch-lcd-7b/esp32-p4-wifi6-touch-lcd-7b.cc
+++ b/main/boards/waveshare-p4-wifi6-touch-lcd-7b/esp32-p4-wifi6-touch-lcd-7b.cc
@@ -30,6 +30,10 @@ private:
     LcdDisplay *display_;
     Esp32Camera* camera_ = nullptr;
 
+    esp_err_t i2c_device_probe(uint8_t addr) {
+        return i2c_master_probe(i2c_bus_, addr, 100);
+    }
+
     void InitializeCodecI2c() {
         // Initialize I2C peripheral
         i2c_master_bus_config_t i2c_bus_cfg = {
@@ -147,6 +151,19 @@ private:
         };
         esp_lcd_panel_io_handle_t tp_io_handle = NULL;
         esp_lcd_panel_io_i2c_config_t tp_io_config = ESP_LCD_TOUCH_IO_I2C_GT911_CONFIG();
+        if (ESP_OK == i2c_device_probe(ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS)) {
+            ESP_LOGI(TAG, "Touch panel found at address 0x%02X", ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS);
+        } else if (ESP_OK == i2c_device_probe(ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP)) {
+            ESP_LOGI(TAG, "Touch panel found at address 0x%02X", ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP);
+            tp_io_config.dev_addr = ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP;
+        } else {
+            ESP_LOGE(TAG, "Touch panel not found on I2C bus");
+            ESP_LOGE(TAG, "Tried addresses: 0x%02X and 0x%02X", 
+                     ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS, 
+                     ESP_LCD_TOUCH_IO_I2C_GT911_ADDRESS_BACKUP);
+            return;
+        }
+
         tp_io_config.scl_speed_hz = 400 * 1000;
         ESP_ERROR_CHECK(esp_lcd_new_panel_io_i2c(i2c_bus_, &tp_io_config, &tp_io_handle));
         ESP_LOGI(TAG, "Initialize touch controller");


### PR DESCRIPTION
GT911的地址不用中断和复位控制的话是会随机跳地址的，所以加上probe逻辑，避免combine的固件运行出错