### PR TITLE
Add GetBatteryLevel for Waveshare ESP32-S3-ePaper-1.54 board

### DIFF
--- a/main/boards/waveshare-s3-epaper-1.54/board_power_bsp.cc
+++ b/main/boards/waveshare-s3-epaper-1.54/board_power_bsp.cc
@@ -15,7 +15,8 @@ void BoardPowerBsp::PowerLedTask(void *arg) {
         gpio_set_level(GPIO_NUM_3, 0);
         vTaskDelay(pdMS_TO_TICKS(200));
         gpio_set_level(GPIO_NUM_3, 1);
-        vTaskDelay(pdMS_TO_TICKS(200));
+        // 不需要频繁闪烁，间隔指示效果更好
+        vTaskDelay(pdMS_TO_TICKS(4800));
     }
 }
 


### PR DESCRIPTION
参考微雪adc样例与其他主板实现，补充ESP32-S3-ePaper-1.54 board的非精确电量显示。