### PR TITLE
Implement actions for SET and REC button clicks

### DIFF
--- a/main/boards/esp32s3-korvo2-v3/config.json
+++ b/main/boards/esp32s3-korvo2-v3/config.json
@@ -3,7 +3,15 @@
     "builds": [
         {
             "name": "esp32s3-korvo2-v3",
-            "sdkconfig_append": []
+            "sdkconfig_append": [
+                "CONFIG_CAMERA_OV2640=y",
+                "CONFIG_CAMERA_OV3660=y",
+                "CONFIG_CAMERA_OV3660_AUTO_DETECT_DVP_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV3660_DVP_RGB565_240X240_24FPS=y",
+                "CONFIG_CAMERA_OV2640_AUTO_DETECT_DVP_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV2640_DVP_RGB565_240X240_25FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
+            ]
         }
     ]
 }

--- a/main/boards/esp32s3-korvo2-v3/esp32s3_korvo2_v3_board.cc
+++ b/main/boards/esp32s3-korvo2-v3/esp32s3_korvo2_v3_board.cc
@@ -230,12 +230,12 @@ private:
 
         auto set_button = adc_button_[BSP_ADC_BUTTON_SET];
         set_button->OnClick([this]() {
-             ESP_LOGI(TAG, "TODO %s:%d\n", __func__, __LINE__);
+            EnterWifiConfigMode();
         });
 
         auto rec_button = adc_button_[BSP_ADC_BUTTON_REC];
         rec_button->OnClick([this]() {
-             ESP_LOGI(TAG, "TODO %s:%d\n", __func__, __LINE__);
+             Application::GetInstance().ToggleChatState();
         });
         boot_button_.OnClick([this]() {});
         boot_button_.OnClick([this]() {

--- a/main/boards/kevin-sp-v4-dev/config.json
+++ b/main/boards/kevin-sp-v4-dev/config.json
@@ -3,7 +3,15 @@
     "builds": [
         {
             "name": "kevin-sp-v4-dev",
-            "sdkconfig_append": []
+            "sdkconfig_append": [
+                "CONFIG_CAMERA_OV2640=y",
+                "CONFIG_CAMERA_OV3660=y",
+                "CONFIG_CAMERA_OV3660_AUTO_DETECT_DVP_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV3660_DVP_RGB565_240X240_24FPS=y",
+                "CONFIG_CAMERA_OV2640_AUTO_DETECT_DVP_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV2640_DVP_RGB565_240X240_25FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
+            ]
         }
     ]
 }

--- a/main/boards/kevin-sp-v4-dev/kevin-sp-v4_board.cc
+++ b/main/boards/kevin-sp-v4-dev/kevin-sp-v4_board.cc
@@ -16,10 +16,9 @@
 
 class KEVIN_SP_V4Board : public WifiBoard {
 private:
-    i2c_master_bus_handle_t display_i2c_bus_;
     Button boot_button_;
     LcdDisplay* display_;
-    i2c_master_bus_handle_t codec_i2c_bus_;
+    i2c_master_bus_handle_t i2c_bus_;
     Esp32Camera* camera_;
 
     void InitializeCodecI2c() {
@@ -36,7 +35,7 @@ private:
                 .enable_internal_pullup = 1,
             },
         };
-        ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_bus_cfg, &codec_i2c_bus_));
+        ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_bus_cfg, &i2c_bus_));
     }
 
     void InitializeSpi() {
@@ -118,12 +117,8 @@ private:
         };
 
         esp_video_init_sccb_config_t sccb_config = {
-            .init_sccb = true,
-            .i2c_config = {
-                .port = 1,
-                .scl_pin = CAMERA_PIN_SIOC,
-                .sda_pin = GPIO_NUM_NC,
-            },
+            .init_sccb = false,
+            .i2c_handle = i2c_bus_,
             .freq = 100000,
         };
 
@@ -159,7 +154,7 @@ public:
     }
 
     virtual AudioCodec* GetAudioCodec() override {
-        static Es8311AudioCodec audio_codec(codec_i2c_bus_, I2C_NUM_0, AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,
+        static Es8311AudioCodec audio_codec(i2c_bus_, I2C_NUM_0, AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,
             AUDIO_I2S_GPIO_MCLK, AUDIO_I2S_GPIO_BCLK, AUDIO_I2S_GPIO_WS, AUDIO_I2S_GPIO_DOUT, AUDIO_I2S_GPIO_DIN,
             AUDIO_CODEC_PA_PIN, AUDIO_CODEC_ES8311_ADDR);
         return &audio_codec;


### PR DESCRIPTION
ESP32S3 Korvo board: Added camera-related configuration options to config.json for OV2640 and OV3660 sensors. Updated SET and REC button click handlers in esp32s3_korvo2_v3_board.cc to call EnterWifiConfigMode and toggle chat state, respectively, replacing placeholder log statements.