### PR TITLE
Fixed the issue where voice wake-up causes panic when DEBUG is enabled.

### DIFF
--- a/main/led/gpio_led.h
+++ b/main/led/gpio_led.h
@@ -32,7 +32,9 @@ class GpioLed : public Led {
     int blink_interval_ms_ = 0;
     esp_timer_handle_t blink_timer_ = nullptr;
     bool fade_up_ = true;
-
+    TaskHandle_t event_task_handle_;
+    
+    static void EventTask(void* arg);
     void StartBlinkTask(int times, int interval_ms);
     void OnBlinkTimer();
 


### PR DESCRIPTION
修复了在gpio-led模式下开启DEBUG时语音唤醒会导致panic的bug。
https://github.com/78/xiaozhi-esp32/issues/1605
之前是在中断中执行了日志打印，现在修改成中断中发通知，线程中执行