### PR TITLE
修复ESP-Hi报错

### DIFF
--- a/main/boards/esp-hi/esp_hi.cc
+++ b/main/boards/esp-hi/esp_hi.cc
@@ -224,7 +224,7 @@ private:
         SetLedColor(0x00, 0x00, 0x00);
 
 #ifdef CONFIG_ESP_HI_WEB_CONTROL_ENABLED
-        ESP_ERROR_CHECK(esp_event_loop_create_default());
+        esp_event_loop_create_default();
         ESP_ERROR_CHECK(esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED,
                                                  &wifi_event_handler, this));
 #endif //CONFIG_ESP_HI_WEB_CONTROL_ENABLED


### PR DESCRIPTION
Windows11
ESP-IDF 5.5.2
VSCode 1.108.0
ESP-IDF扩展 1.11.0
报错内容片段如下，经AI查证是事件循环未初始化，测试该修改可以修复，没有完全测试ESP_ERROR_CHECK相关功能，但是有没有都可以正常运行了:
```
I (31) cpu_start: Unicore app
I (39) cpu_start: GPIO 20 and 21 are used as console UART I/O pins
I (39) cpu_start: Pro cpu start user code
I (39) cpu_start: cpu freq: 160000000 Hz
I (41) app_init: Application information:
I (45) app_init: Project name:     xiaozhi
I (49) app_init: App version:      2.1.0
I (52) app_init: Compile time:     Jan  9 2026 17:47:19
I (57) app_init: ELF file SHA256:  f735c93f0...
.I (61) app_init: ESP-IDF:          v5.5.2
I (65) efuse_init: Min chip rev:     v0.3
I (69) efuse_init: Max chip rev:     v1.99
I (73) efuse_init: Chip rev:         v0.4
I (77) heap_init: Initializing. RAM available for dynamic allocation:
I (83) heap_init: At 3FC9E340 len 00021CC0 (135 KiB): RAM
I (88) heap_init: At 3FCC0000 len 0001C710 (113 KiB): Retention RAM
I (94) heap_init: At 3FCDC710 len 00002950 (10 KiB): Retention RAM
I (100) heap_init: At 50000020 len 00001FB8 (7 KiB): RTCRAM
I (106) spi_flash: detected chip: generic
I (109) spi_flash: flash io: dio
I (113) sleep_gpio: Configure to isolate all GPIO pins in sleep state
I (118) sleep_gpio: Enable automatic switching of GPIO sleep configuration
I (125) main_task: Started on CPU0
I (125) main_task: Calling app_main()
I (135) Board: UUID=0e0cb7b5-41d9-4c86-8453-4622b0d6e934 SKU=esp-hi
I (135) button: IoT Button Version: 4.1.5
I (135) ESP_HI: Initialize Iot
I (135) ESP_HI: BLINK_GPIO setting 8
ESP_ERROR_CHECK failed: esp_err_t 0x103 (ESP_ERR_INVALID_STATE) at 0x4201ca60
--- 0x4201ca60: EspHi::InitializeIot() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/boards/esp-hi/esp_hi.cc:227
file: "./main/boards/esp-hi/esp_hi.cc" line 227
func: void EspHi::InitializeIot()
expression: esp_event_handler_register(WIFI_EVENT, WIFI_EVENT_STA_CONNECTED, &wifi_event_handler, this)

abort() was called at PC 0x403885bf on core 0
.--- 0x403885bf: _esp_error_check_failed at C:/Users/m2002/esp/v5.5.2/esp-idf/components/esp_system/esp_err.c:49
Core  0 register dump:
MEPC    : 0x40388604  RA      : 0x403885c8  SP      : 0x3fca2430  GP      : 0x3fc93200
.--- 0x40388604: panic_abort at C:/Users/m2002/esp/v5.5.2/esp-idf/components/esp_system/panic.c:491
--- 0x403885c8: esp_vApplicationTickHook at C:/Users/m2002/esp/v5.5.2/esp-idf/components/esp_system/freertos_hooks.c:31
TP      : 0x3fca2620  T0      : 0x37363534  T1      : 0x7271706f  T2      : 0x33323130
S0/FP   : 0x3fca246c  S1      : 0x3fca246c  A0      : 0x3fca246c  A1      : 0x3fca244e
A2      : 0x00000000  A3      : 0x3fca2499  A4      : 0x00000001  A5      : 0x3fc9e000
A6      : 0x7a797877  A7      : 0x76757473  S2      : 0x3fca2450  S3      : 0x3fca4f78
S4      : 0x3fca4fe0  S5      : 0x00000000  S6      : 0x00000000  S7      : 0x00000000
S8      : 0x00000000  S9      : 0x00000000  S10     : 0x00000000  S11     : 0x00000000
T3      : 0x6e6d6c6b  T4      : 0x6a696867  T5      : 0x66656463  T6      : 0x62613938
MSTATUS : 0x00001881  MTVEC   : 0x40380001  MCAUSE  : 0x00000002  MTVAL   : 0x00000000
--- 0x40380001: _vector_table at C:/Users/m2002/esp/v5.5.2/esp-idf/components/riscv/vectors_intc.S:54
MHARTID : 0x00000000

Stack memory:
3fca2430: 0x00000000 0x00000000 0x3fca246c 0x40390016 0x00000000 0x00000000 0x3fca4fe0 0x3fca0030
--- 0x40390016: __assert_func at C:/Users/m2002/esp/v5.5.2/esp-idf/components/newlib/src/assert.c:33
3fca2450: 0x38333034 0x66623538 0x3fca4e00 0x3fc963b4 0x3fca2450 0x3fc963d0 0x3fca244c 0x726f6261
3fca2470: 0x20292874 0x20736177 0x6c6c6163 0x61206465 0x43502074 0x34783020 0x38383330 0x20666235
3fca2490: 0x63206e6f 0x2065726f 0x00000030 0x3c150000 0x3fca4f10 0x3fca4edc 0x3fca4edc 0x403885c2
.--- 0x403885c2: esp_system_abort at C:/Users/m2002/esp/v5.5.2/esp-idf/components/esp_system/port/esp_system_chip.c:86
3fca24b0: 0x3fca4f10 0x3fca4edc 0x3fca4edc 0x4201ca64 0x3fca4f10 0x3fca4edc 0x3fca4edc 0x4201d5d4
--- 0x4201ca64: EspHi::InitializeIot() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/boards/esp-hi/esp_hi.cc:230
--- 0x4201d5d4: EspHi::InitializeSpi() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/boards/esp-hi/esp_hi.cc:234
--- (inlined by) EspHi::EspHi() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/boards/esp-hi/esp_hi.cc:398
3fca24d0: 0x00001800 0x00000000 0x3fc9e6f0 0x403808a4 0x00000000 0x00001800 0x0000017c 0x00000004
--- 0x403808a4: heap_caps_aligned_alloc_base at C:/Users/m2002/esp/v5.5.2/esp-idf/components/heap/heap_caps_base.c:177
3fca24f0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00001800 0x0000017c 0x0000017c 0x403804f8
--- 0x403804f8: heap_caps_malloc at C:/Users/m2002/esp/v5.5.2/esp-idf/components/heap/heap_caps.c:84
3fca2510: 0x00000000 0x3fc9e000 0x00000000 0x00000000 0x00000000 0x3fc9e000 0x3fca4edc 0x4201d690
.--- 0x4201d690: create_board() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/boards/esp-hi/esp_hi.cc:421
3fca2530: 0x00000000 0x3fc9e000 0x3fc9e000 0x4200ad22 0x00000001 0x3fc98040 0x3fc98000 0x42011e6c
--- 0x4200ad22: Board::GetInstance() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/boards/common/board.h:63
--- 0x42011e6c: Application::Initialize() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/application.cc:63
3fca2550: 0x00000000 0x00000020 0x3fca259c 0x40380628 0x00000000 0x00000000 0x3fca3cd8 0x40388798
--- 0x40380628: heap_caps_calloc at C:/Users/m2002/esp/v5.5.2/esp-idf/components/heap/heap_caps.c:255
--- 0x40388798: prvCopyDataToQueue at C:/Users/m2002/esp/v5.5.2/esp-idf/components/freertos/FreeRTOS-Kernel/queue.c:2470
3fca2570: 0x00000000 0x00000000 0x3fca3cd8 0x40388dfa 0x3fc9dbc0 0x42013e9a 0x00000002 0x00000000
--- 0x40388dfa: xQueueGenericSend at C:/Users/m2002/esp/v5.5.2/esp-idf/components/freertos/FreeRTOS-Kernel/queue.c:966
--- 0x42013e9a: Application::~Application() at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/application.cc:49
3fca2590: 0x00000000 0x00000000 0x00000000 0x3fc97f5c 0x00000000 0x00000000 0x00000000 0x00000000
3fca25b0: 0x00000000 0x00000002 0x00000000 0x00000000 0x00000000 0x3fc9e000 0x3fc98000 0x42017f98
.--- 0x42017f98: app_main at C:/OneDrive - MSFT/Code/xiaozhi-esp32-2.1.0/main/main.cc:29
3fca25d0: 0x3c153aac 0x00000000 0x3c154000 0x42143008 0x00000000 0x00002710 0x00000001 0x00000000
--- 0x42143008: main_task at C:/Users/m2002/esp/v5.5.2/esp-idf/components/freertos/app_startup.c:209
3fca25f0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
3fca2610: 0x00000000 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0x00000160 0x3fca2360 0x00000000
3fca2630: 0x3fc9776c 0x3fc9776c 0x3fca2628 0x3fc97764 0x00000018 0x3fca5558 0x3fca5558 0x3fca2628
3fca2650: 0x00000000 0x00000001 0x3fca0624 0x6e69616d 0x00000000 0x00000000 0x00000000 0x3fca2620
3fca2670: 0x00000002 0x00000000 0x00000001 0x00000000 0x00000000 0x00000000 0x00009cad 0x00000000
3fca2690: 0x3fc9e994 0x3fc9e9fc 0x3fc9ea64 0x00000000 0x00000000 0x00000001 0x00000000 0x00000000
3fca26b0: 0x00000000 0x42004684 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
--- 0x42004684: esp_cleanup_r at C:/Users/m2002/esp/v5.5.2/esp-idf/components/newlib/src/newlib_init.c:42
3fca26d0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
3fca26f0: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
3fca2710: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
3fca2730: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
3fca2750: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000
3fca2770: 0x00000000 0x00000000 0x00000000 0x00000000 0x00000000 0x3fca2620 0x00000300 0xa5a5a5a5
3fca2790: 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5
3fca27b0: 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5
3fca27d0: 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5
3fca27f0: 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5
3fca2810: 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5 0xa5a5a5a5



ELF file SHA256: f735c93f0

Rebooting...
ESP-ROM:esp32c3-api1-20210207
Build:Feb  7 2021
rst:0xc (RTC_SW_CPU_RST),boot:0xc (SPI_FAST_FLASH_BOOT)
Saved PC:0x403886c8
--- 0x403886c8: esp_restart_noos at C:/Users/m2002/esp/v5.5.2/esp-idf/components/esp_system/port/soc/esp32c3/system_internal.c:115
SPIWP:0xee
mode:DIO, clock div:1
load:0x3fcd5820,len:0x3b8
load:0x403cbf10,len:0x9bc
load:0x403ce710,len:0x2c14
entry 0x403cbf10
```