### PR TITLE
Enhance audio service: Add mutex for input resampler and reset logic …

### DIFF
--- a/main/audio/audio_service.h
+++ b/main/audio/audio_service.h
@@ -142,6 +142,7 @@ private:
     void* opus_encoder_ = nullptr;
     void* opus_decoder_ = nullptr;
     std::mutex decoder_mutex_;
+    std::mutex input_resampler_mutex_;
     esp_ae_rate_cvt_handle_t input_resampler_ = nullptr;
     esp_ae_rate_cvt_handle_t output_resampler_ = nullptr;
     


### PR DESCRIPTION
This pull request improves thread safety and stability in the audio service by introducing a dedicated mutex for the input resampler and ensuring its state is properly reset when switching between wake word detection and voice processing modes. These changes help prevent buffer overflows and potential race conditions when handling audio data.

### Thread safety improvements

* Added a dedicated `input_resampler_mutex_` to the `AudioService` class to protect access to the `input_resampler_` object.
* Wrapped all accesses to `input_resampler_` in `ReadAudioData` with a `std::lock_guard` to ensure thread-safe operations during audio data reading.

### Stability and buffer management

* Reset the input resampler with proper locking when enabling wake word detection, preventing buffer overflows caused by cached data from previous modes.
* Reset the input resampler with proper locking when enabling voice processing, ensuring clean state transitions and preventing buffer overflows when switching feed sizes.