### PR TITLE
feat(oled): Implement brightness control and auto-power save for bread-compact-wifi

### DIFF
--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -510,6 +510,13 @@ choice DISPLAY_OLED_TYPE
         bool "SH1106 128*64"
 endchoice
 
+config OLED_AUTO_POWER_SAVE
+    bool "Enable OLED Auto Power Save"
+    depends on BOARD_TYPE_BREAD_COMPACT_WIFI
+    help
+        Automatically turn off the OLED display after a period of inactivity.
+        The screen wakes up on button press or voice activity.
+
 choice DISPLAY_LCD_TYPE
     depends on BOARD_TYPE_BREAD_COMPACT_WIFI_LCD || BOARD_TYPE_BREAD_COMPACT_ESP32_LCD || BOARD_TYPE_CGC || BOARD_TYPE_WAVESHARE_P4_NANO || BOARD_TYPE_WAVESHARE_P4_WIFI6_TOUCH_LCD_XC || BOARD_TYPE_BREAD_COMPACT_WIFI_CAM
     prompt "LCD Type"

--- a/main/boards/bread-compact-wifi/compact_wifi_board.cc
+++ b/main/boards/bread-compact-wifi/compact_wifi_board.cc
@@ -9,7 +9,9 @@
 #include "lamp_controller.h"
 #include "led/single_led.h"
 #include "assets/lang_config.h"
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
 #include "power_save_timer.h"
+#endif
 
 #include <esp_log.h>
 #include <driver/i2c_master.h>
@@ -22,6 +24,8 @@
 
 #define TAG "CompactWifiBoard"
 
+static constexpr int kPowerSaveTimeoutSeconds = 60;
+
 class CompactWifiBoard : public WifiBoard {
 private:
     i2c_master_bus_handle_t display_i2c_bus_;
@@ -32,10 +36,11 @@ private:
     Button touch_button_;
     Button volume_up_button_;
     Button volume_down_button_;
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
     PowerSaveTimer* power_save_timer_;
 
     void InitializePowerSaveTimer() {
-        power_save_timer_ = new PowerSaveTimer(-1, 60, -1);
+        power_save_timer_ = new PowerSaveTimer(-1, kPowerSaveTimeoutSeconds, -1);
         power_save_timer_->OnEnterSleepMode([this]() {
             GetDisplay()->SetPowerSaveMode(true);
         });
@@ -44,6 +49,7 @@ private:
         });
         power_save_timer_->SetEnabled(true);
     }
+#endif
 
     void InitializeDisplayI2c() {
         i2c_master_bus_config_t bus_config = {
@@ -115,7 +121,9 @@ private:
 
     void InitializeButtons() {
         boot_button_.OnClick([this]() {
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
             power_save_timer_->WakeUp();
+#endif
             auto& app = Application::GetInstance();
             if (app.GetDeviceState() == kDeviceStateStarting) {
                 EnterWifiConfigMode();
@@ -124,16 +132,22 @@ private:
             app.ToggleChatState();
         });
         touch_button_.OnPressDown([this]() {
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
             power_save_timer_->WakeUp();
+#endif
             Application::GetInstance().StartListening();
         });
         touch_button_.OnPressUp([this]() {
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
             power_save_timer_->WakeUp();
+#endif
             Application::GetInstance().StopListening();
         });
 
         volume_up_button_.OnClick([this]() {
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
             power_save_timer_->WakeUp();
+#endif
             auto codec = GetAudioCodec();
             auto volume = codec->output_volume() + 10;
             if (volume > 100) {
@@ -144,13 +158,17 @@ private:
         });
 
         volume_up_button_.OnLongPress([this]() {
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
             power_save_timer_->WakeUp();
+#endif
             GetAudioCodec()->SetOutputVolume(100);
             GetDisplay()->ShowNotification(Lang::Strings::MAX_VOLUME);
         });
 
         volume_down_button_.OnClick([this]() {
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
             power_save_timer_->WakeUp();
+#endif
             auto codec = GetAudioCodec();
             auto volume = codec->output_volume() - 10;
             if (volume < 0) {
@@ -161,7 +179,9 @@ private:
         });
 
         volume_down_button_.OnLongPress([this]() {
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
             power_save_timer_->WakeUp();
+#endif
             GetAudioCodec()->SetOutputVolume(0);
             GetDisplay()->ShowNotification(Lang::Strings::MUTED);
         });
@@ -180,7 +200,9 @@ public:
         volume_down_button_(VOLUME_DOWN_BUTTON_GPIO) {
         InitializeDisplayI2c();
         InitializeSsd1306Display();
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
         InitializePowerSaveTimer();
+#endif
         InitializeButtons();
         InitializeTools();
     }
@@ -210,12 +232,14 @@ public:
         return &backlight;
     }
 
+#ifdef CONFIG_OLED_AUTO_POWER_SAVE
     virtual void SetPowerSaveLevel(PowerSaveLevel level) override {
         if (level != PowerSaveLevel::LOW_POWER) {
             power_save_timer_->WakeUp();
         }
         WifiBoard::SetPowerSaveLevel(level);
     }
+#endif
 };
 
 DECLARE_BOARD(CompactWifiBoard);

--- a/main/boards/common/backlight.h
+++ b/main/boards/common/backlight.h
@@ -13,7 +13,7 @@ public:
     ~Backlight();
 
     void RestoreBrightness();
-    void SetBrightness(uint8_t brightness, bool permanent = false);
+    virtual void SetBrightness(uint8_t brightness, bool permanent = false);
     inline uint8_t brightness() const { return brightness_; }
 
 protected:

--- a/main/display/oled_display.cc
+++ b/main/display/oled_display.cc
@@ -1,4 +1,5 @@
 #include "oled_display.h"
+#include "settings.h"
 #include "assets/lang_config.h"
 #include "lvgl_theme.h"
 #include "lvgl_font.h"
@@ -411,6 +412,25 @@ void OledDisplay::SetContrast(uint8_t contrast) {
 
 OledBacklight::OledBacklight(OledDisplay* display) : display_(display) {
     brightness_ = 50;
+}
+
+void OledBacklight::SetBrightness(uint8_t brightness, bool permanent) {
+    if (brightness > 100) {
+        brightness = 100;
+    }
+    if (brightness_ == brightness) {
+        return;
+    }
+
+    if (permanent) {
+        Settings settings("display", true);
+        settings.SetInt("brightness", brightness);
+    }
+
+    brightness_ = brightness;
+    target_brightness_ = brightness;
+    SetBrightnessImpl(brightness);
+    ESP_LOGI(TAG, "Set OLED brightness to %d", brightness);
 }
 
 void OledBacklight::SetBrightnessImpl(uint8_t brightness) {

--- a/main/display/oled_display.h
+++ b/main/display/oled_display.h
@@ -43,7 +43,8 @@ public:
 class OledBacklight : public Backlight {
 public:
     OledBacklight(OledDisplay* display);
-    virtual void SetBrightnessImpl(uint8_t brightness) override;
+    void SetBrightness(uint8_t brightness, bool permanent = false) override;
+    void SetBrightnessImpl(uint8_t brightness) override;
 
 private:
     OledDisplay* display_;

--- a/main/display/oled_display.h
+++ b/main/display/oled_display.h
@@ -2,6 +2,7 @@
 #define OLED_DISPLAY_H
 
 #include "lvgl_display.h"
+#include "backlight.h"
 
 #include <esp_lcd_panel_io.h>
 #include <esp_lcd_panel_ops.h>
@@ -35,6 +36,17 @@ public:
     virtual void SetChatMessage(const char* role, const char* content) override;
     virtual void SetEmotion(const char* emotion) override;
     virtual void SetTheme(Theme* theme) override;
+    virtual void SetPowerSaveMode(bool on) override;
+    void SetContrast(uint8_t contrast);
+};
+
+class OledBacklight : public Backlight {
+public:
+    OledBacklight(OledDisplay* display);
+    virtual void SetBrightnessImpl(uint8_t brightness) override;
+
+private:
+    OledDisplay* display_;
 };
 
 #endif // OLED_DISPLAY_H


### PR DESCRIPTION
## Description
This PR implements comprehensive power management and brightness control for OLED displays, specifically targeting the `bread-compact-wifi` board.

### Key Features:
1.  **Hardware Power Control**: Implemented `SetPowerSaveMode` in `OledDisplay` to use `esp_lcd_panel_disp_on_off` for true hardware sleep/wake.
2.  **Brightness/Contrast Control**:
    *   Added `SetContrast` using command `0x81`.
    *   Implemented `OledBacklight` adapter to map brightness (0-100) to contrast (0-255).
    *   **Smart Threshold**: Setting brightness <= 5% turns off the display power completely; > 5% turns it on and sets contrast.
3.  **Auto Power Save**:
    *   Integrated `PowerSaveTimer` in `CompactWifiBoard`.
    *   Automatically turns off the screen after 60 seconds of inactivity.
    *   Wakes up on Button (Boot, Touch, Volume) events or Voice activity.
4.  **MCP Integration**: Exposed `OledBacklight` via `GetBacklight`, enabling the standard `self.screen.set_brightness` tool for voice control (e.g., "Turn off screen", "Set brightness to 50").

### Testing
- Validated on `bread-compact-wifi-128x64`.
- Verified voice commands for brightness and screen on/off.
- Verified auto-sleep timeout.


### Related Issue
- #796