### PR TITLE
BLUFI：修复IDF5.5.2后乐鑫 BLUFI 配网 APP 无法扫描发现设备问题

### DIFF
--- a/main/boards/common/blufi.h
+++ b/main/boards/common/blufi.h
@@ -21,6 +21,12 @@ public:
     static Blufi &GetInstance();
 
     /**
+     * @brief Get the Bluetooth name for Blufi provisioning("BLUFI_Xiaozhi_XXXX")
+     * @return Bluetooth name
+     */
+    std::string GetBlufiBleName();
+
+    /**
      * @brief Start WiFi scan for Blufi provisioning
      * This method intelligently handles WiFi scanning based on current WiFi state:
      * - If WiFi config mode is active, it uses the existing scan results from WifiConfigurationAp
@@ -48,6 +54,7 @@ public:
 
 private:
     bool inited_ = false;
+    std::string blufi_ble_name_;
 
     Blufi();
 


### PR DESCRIPTION
问题描述
ESP-IDF 5.5.2 对 BLUFI 广播逻辑做调整，原`esp_blufi_adv_start(void)`函数移除了内置蓝牙名配置逻辑，导致设备广播无含BLUFI关键字的名称，乐鑫官方配网 APP 无法扫描过滤设备，配网流程完全失效。
修复与优化方案
使用新函数`esp_blufi_adv_start_with_name(const char *name)`替代原无参广播函数，通过入参传入自定义蓝牙名；
新增成员变量`std::string blufi_ble_name_`，用于存储 BLUFI 蓝牙设备名，统一管理命名数据；
新增接口`std::string Blufi::GetBlufiBleName()`，提供蓝牙名构建/获取能力，方便外部调用与后续扩展；
定义蓝牙名固定范式为`BLUFI_Xiaozhi_XXXX`，保证名称含乐鑫配网 APP 所需的 BLUFI 关键字，满足APP扫描过滤规范。