### PR TITLE
Refactor audio channel handling and wake word detection in Applicatio…

### DIFF
--- a/main/application.h
+++ b/main/application.h
@@ -153,6 +153,8 @@ private:
     void HandleNetworkDisconnectedEvent();
     void HandleActivationDoneEvent();
     void HandleWakeWordDetectedEvent();
+    void ContinueOpenAudioChannel(ListeningMode mode);
+    void ContinueWakeWordInvoke(const std::string& wake_word);
 
     // Activation task (runs in background)
     void ActivationTask();


### PR DESCRIPTION
This pull request refactors how audio channel opening and wake word handling are performed, ensuring that UI state changes are processed before potentially blocking operations. The main improvement is the introduction of scheduled continuation methods, which help prevent UI freezes and race conditions by deferring audio channel operations until after the device state has updated.

**Refactoring for scheduled audio channel operations:**

* Introduced `ContinueOpenAudioChannel` and `ContinueWakeWordInvoke` methods to defer audio channel opening and wake word invocation until after device state changes, improving UI responsiveness and preventing race conditions. (`main/application.cc`, `main/application.h`) [[1]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81R694-R725) [[2]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81L729-L733) [[3]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81R783-L774) [[4]](diffhunk://#diff-135192015344bdaf58e879aa9dfa25fea1f77d081fb60ff3b46f0984f424edc0R156-R157) [[5]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81L963-R1006)

**Improvements to event handling logic:**

* Updated `HandleToggleChatEvent`, `HandleStartListeningEvent`, and `HandleWakeWordDetectedEvent` to use scheduling for audio channel operations, ensuring state changes are processed first and simplifying the control flow. (`main/application.cc`) [[1]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81R694-R725) [[2]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81L729-L733) [[3]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81R783-L774)
* Moved wake word handling logic out of `HandleWakeWordDetectedEvent` into the new continuation method, cleaning up the event handler and making the code easier to follow. (`main/application.cc`) [[1]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81L790-L795) [[2]](diffhunk://#diff-b81a4ddafc264092c11f78dc0edb858283558f78c982f7cfaf698a02216a6f81R783-L774)

**Code organization:**

* Declared the new continuation methods in the `Application` class header for better encapsulation and clarity. (`main/application.h`)