### PR TITLE
Fix AfeWakeWord: Ringbuffer of AFE(FEED) is full

### DIFF
--- a/main/audio/wake_words/afe_wake_word.cc
+++ b/main/audio/wake_words/afe_wake_word.cc
@@ -108,6 +108,9 @@ void AfeWakeWord::Feed(const std::vector<int16_t>& data) {
     if (afe_data_ == nullptr) {
         return;
     }
+    if (!(xEventGroupGetBits(event_group_) & DETECTION_RUNNING_EVENT)) {
+        return;
+    }
     afe_iface_->feed(afe_data_, data.data());
 }
 


### PR DESCRIPTION
This pull request makes a small but important change to the `AfeWakeWord::Feed` method. Now, the function checks whether the `DETECTION_RUNNING_EVENT` bit is set in `event_group_` before feeding data, ensuring audio data is only processed when detection is active.

* Added a check to ensure `AfeWakeWord::Feed` only processes audio data if the `DETECTION_RUNNING_EVENT` flag is set in `event_group_`, preventing unnecessary or invalid processing when detection is not running.…n detection is not running. This enhances the robustness of the wake word detection logic.

Related issues:

https://github.com/78/xiaozhi-esp32/issues/1486 https://github.com/78/xiaozhi-esp32/issues/1612