### PR TITLE
Update ml307 component version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ tmp/
 components/
 managed_components/
 build/
+dist/
 .vscode/
 .devcontainer/
 sdkconfig.old

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -779,6 +779,8 @@ if(CONFIG_IDF_TARGET_ESP32)
                              "display/lvgl_display/jpg/image_to_jpeg.cpp"
                              "display/lvgl_display/jpg/jpeg_to_image.c"
                              "boards/common/nt26_board.cc"
+                             "boards/common/ml307_board.cc"
+                             "boards/common/dual_network_board.cc"
                              )
 endif()
 

--- a/main/boards/bread-compact-esp32/esp32_bread_board.cc
+++ b/main/boards/bread-compact-esp32/esp32_bread_board.cc
@@ -1,4 +1,4 @@
-#include "dual_network_board.h"
+#include "wifi_board.h"
 #include "codecs/no_audio_codec.h"
 #include "system_reset.h"
 #include "application.h"
@@ -16,7 +16,7 @@
 
 #define TAG "ESP32-MarsbearSupport"
 
-class CompactWifiBoard : public DualNetworkBoard {
+class CompactWifiBoard : public WifiBoard {
 private:
     Button boot_button_;
     Button touch_button_;
@@ -104,24 +104,12 @@ private:
 
         boot_button_.OnClick([this]() {
             auto& app = Application::GetInstance();
-            if (GetNetworkType() == NetworkType::WIFI) {
-                if (app.GetDeviceState() == kDeviceStateStarting) {
-                    // cast to WifiBoard
-                    auto& wifi_board = static_cast<WifiBoard&>(GetCurrentBoard());
-                    wifi_board.EnterWifiConfigMode();
-                    return;
-                }
+            if (app.GetDeviceState() == kDeviceStateStarting) {
+                EnterWifiConfigMode();
+                return;
             }
             gpio_set_level(BUILTIN_LED_GPIO, 1);
             app.ToggleChatState();
-        });
-
-
-        boot_button_.OnDoubleClick([this]() {
-            auto& app = Application::GetInstance();
-            if (app.GetDeviceState() == kDeviceStateStarting || app.GetDeviceState() == kDeviceStateWifiConfiguring) {
-                SwitchNetworkType();
-            }
         });
 
         asr_button_.OnClick([this]() {
@@ -145,7 +133,7 @@ private:
     }
 
 public:
-    CompactWifiBoard() : DualNetworkBoard(ML307_TX_PIN, ML307_RX_PIN), boot_button_(BOOT_BUTTON_GPIO), touch_button_(TOUCH_BUTTON_GPIO), asr_button_(ASR_BUTTON_GPIO)
+    CompactWifiBoard() : WifiBoard(), boot_button_(BOOT_BUTTON_GPIO), touch_button_(TOUCH_BUTTON_GPIO), asr_button_(ASR_BUTTON_GPIO)
     {
         InitializeDisplayI2c();
         InitializeSsd1306Display();

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -22,9 +22,9 @@ dependencies:
   78/esp-wifi-connect: ~3.0.2
   espressif/esp_audio_effects: ~1.2.1
   espressif/esp_audio_codec: ~2.4.1
-  78/esp-ml307: ~3.6.0
+  78/esp-ml307: ~3.6.2
   78/uart-eth-modem:
-    version: ~0.2.1
+    version: ~0.3.0
     rules:
     - if: target not in [esp32]
   78/xiaozhi-fonts: ~1.6.0


### PR DESCRIPTION
This pull request introduces a minor dependency update and a small logic improvement to the wake word detection audio feed. The main changes are:

Dependency update:

* Updated the `78/esp-ml307` dependency from version `~3.5.3` to `~3.6.0` in `main/idf_component.yml`.

esp-ml307 3.6.0 uses UART DMA to communicate with AT modules.