### PR TITLE
在Display基类中添加SetupUI虚函数

### DIFF
--- a/main/application.cc
+++ b/main/application.cc
@@ -64,7 +64,7 @@ void Application::Initialize() {
 
     // Setup the display
     auto display = board.GetDisplay();
-
+    display->SetupUI();
     // Print board name/version info
     display->SetChatMessage("system", SystemInfo::GetUserAgent().c_str());
 

--- a/main/display/display.h
+++ b/main/display/display.h
@@ -40,6 +40,7 @@ public:
     virtual Theme* GetTheme() { return current_theme_; }
     virtual void UpdateStatusBar(bool update_all = false);
     virtual void SetPowerSaveMode(bool on);
+    virtual void SetupUI() { }
 
     inline int width() const { return width_; }
     inline int height() const { return height_; }

--- a/main/display/lcd_display.cc
+++ b/main/display/lcd_display.cc
@@ -169,8 +169,6 @@ SpiLcdDisplay::SpiLcdDisplay(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_h
     if (offset_x != 0 || offset_y != 0) {
         lv_display_set_offset(display_, offset_x, offset_y);
     }
-
-    SetupUI();
 }
 
 
@@ -232,8 +230,6 @@ RgbLcdDisplay::RgbLcdDisplay(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_h
     if (offset_x != 0 || offset_y != 0) {
         lv_display_set_offset(display_, offset_x, offset_y);
     }
-
-    SetupUI();
 }
 
 MipiLcdDisplay::MipiLcdDisplay(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_handle_t panel,
@@ -285,8 +281,6 @@ MipiLcdDisplay::MipiLcdDisplay(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel
     if (offset_x != 0 || offset_y != 0) {
         lv_display_set_offset(display_, offset_x, offset_y);
     }
-
-    SetupUI();
 }
 
 LcdDisplay::~LcdDisplay() {

--- a/main/display/lcd_display.h
+++ b/main/display/lcd_display.h
@@ -37,7 +37,6 @@ protected:
     bool hide_subtitle_ = false;  // Control whether to hide chat messages/subtitles
 
     void InitializeLcdThemes();
-    void SetupUI();
     virtual bool Lock(int timeout_ms = 0) override;
     virtual void Unlock() override;
 
@@ -51,7 +50,7 @@ public:
     virtual void SetChatMessage(const char* role, const char* content) override;
     virtual void ClearChatMessages() override;
     virtual void SetPreviewImage(std::unique_ptr<LvglImage> image) override;
-
+    virtual void SetupUI() override;
     // Add theme switching function
     virtual void SetTheme(Theme* theme) override;
     


### PR DESCRIPTION
在Display基类中添加SetupUI虚函数,移除LcdDisplay构造函数中调用SetupUI函数.
在Application的Initialize函数中调用display的SetupUI函数.以实现不同board自定义UI功能.
此修改兼容现有代码.无需求修改其它board代码实现.