### PR TITLE
Update low battery popup handling in LvglDisplay class

### DIFF
--- a/main/display/lvgl_display/lvgl_display.cc
+++ b/main/display/lvgl_display/lvgl_display.cc
@@ -174,11 +174,15 @@ void LvglDisplay::UpdateStatusBar(bool update_all) {
             lv_label_set_text(battery_label_, battery_icon_);
         }
 
-        if (low_battery_popup_ != nullptr) {
+        // Check low battery popup only when clock tick event is triggered
+        // Because when initializing, the battery level is not ready yet.
+        if (low_battery_popup_ != nullptr && !update_all) {
             if (strcmp(icon, FONT_AWESOME_BATTERY_EMPTY) == 0 && discharging) {
                 if (lv_obj_has_flag(low_battery_popup_, LV_OBJ_FLAG_HIDDEN)) { // Show if low battery popup is hidden
                     lv_obj_remove_flag(low_battery_popup_, LV_OBJ_FLAG_HIDDEN);
-                    app.PlaySound(Lang::Sounds::OGG_LOW_BATTERY);
+                    app.Schedule([&app]() {
+                        app.PlaySound(Lang::Sounds::OGG_LOW_BATTERY);
+                    });
                 }
             } else {
                 // Hide the low battery popup when the battery is not empty


### PR DESCRIPTION
- Adjusted the logic to check for low battery popup visibility only during clock tick events, ensuring it does not trigger during initialization when battery level is not ready.
- Implemented a scheduled task to play the low battery sound, improving responsiveness and avoiding immediate playback during UI updates.