### PR TITLE
fix: add frame buffering to NoAudioProcessor for ESP32-C5

### DIFF
--- a/main/audio/processors/no_audio_processor.h
+++ b/main/audio/processors/no_audio_processor.h
@@ -26,6 +26,7 @@ public:
 private:
     AudioCodec* codec_ = nullptr;
     int frame_samples_ = 0;
+    std::vector<int16_t> output_buffer_;
     std::function<void(std::vector<int16_t>&& data)> output_callback_;
     std::function<void(bool speaking)> vad_state_change_callback_;
     std::atomic<bool> is_running_ = false;

--- a/main/boards/movecall-moji2-esp32c5/config.json
+++ b/main/boards/movecall-moji2-esp32c5/config.json
@@ -6,7 +6,6 @@
             "sdkconfig_append": [
                 "CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y",
                 "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/16m.csv\"",
-                "CONFIG_PM_ENABLE=y",
                 "CONFIG_FREERTOS_USE_TICKLESS_IDLE=y",
                 "CONFIG_SPIRAM_MODE_QUAD=y",
                 "CONFIG_SPIRAM_SPEED_80M=y",

--- a/main/boards/movecall-moji2-esp32c5/movecall_moji2_esp32s3.cc
+++ b/main/boards/movecall-moji2-esp32c5/movecall_moji2_esp32s3.cc
@@ -227,16 +227,19 @@ private:
     void InitializeBatteryMonitor() {
         adc_battery_monitor_ = new AdcBatteryMonitor(ADC_UNIT_1, ADC_CHANNEL_3, 5100000, 5100000, GPIO_NUM_NC);
         adc_battery_monitor_->OnChargingStatusChanged([this](bool is_charging) {
-            if (is_charging) {
-                power_save_timer_->SetEnabled(false);
-            } else {
-                power_save_timer_->SetEnabled(true);
+            if (power_save_timer_ != nullptr){
+                if (is_charging) {
+                    power_save_timer_->SetEnabled(false);
+                } else {
+                    power_save_timer_->SetEnabled(true);
+                }
             }
+
         });
     }
 
     void InitializePowerSaveTimer() {
-        power_save_timer_ = new PowerSaveTimer(240, 300);
+        power_save_timer_ = new PowerSaveTimer(240, -1, -1);
         power_save_timer_->OnEnterSleepMode([this]() {
             GetDisplay()->SetPowerSaveMode(true);
         });
@@ -348,8 +351,8 @@ private:
 public:
     MovecallMoji2ESP32C5() : boot_button_(BOOT_BUTTON_GPIO) {  
         InitializeCodecI2c();
-        InitializeBatteryMonitor();
         InitializePowerSaveTimer();
+        InitializeBatteryMonitor();
         InitializeSpi();
         InitializeSt77916Display();
         InitializeButtons();


### PR DESCRIPTION
问题描述：
ESP32-C5 在使用 NoAudioProcessor 时，直接透传 160 采样（10ms）的数据，但 Opus 编码器要求 960 采样（60ms）。这导致编码报错、CPU 满载并触发看门狗复位。

修复方案：

    音频缓存： 在 NoAudioProcessor 中增加缓存机制，积攒满 960 采样后再输出，使之与编码器要求对齐。
    稳定性优化： 关闭睡眠模式（PowerSaveTimer），确保单核芯片处理音频流时的实时性。

测试方案：
在 ESP32-C5 硬件上通过“你好小智”唤醒测试，系统不再重启，语音上传恢复正常。