### PR TITLE
fix: waveshare ESP32-S3-Touch-AMOLED-1.75 Touch bugs

### DIFF
--- a/main/boards/waveshare/esp32-s3-touch-amoled-1.75/esp32-s3-touch-amoled-1.75.cc
+++ b/main/boards/waveshare/esp32-s3-touch-amoled-1.75/esp32-s3-touch-amoled-1.75.cc
@@ -268,7 +268,7 @@ private:
             .x_max = DISPLAY_WIDTH - 1,
             .y_max = DISPLAY_HEIGHT - 1,
             .rst_gpio_num = GPIO_NUM_40,
-            .int_gpio_num = GPIO_NUM_NC,
+            .int_gpio_num = GPIO_NUM_11,
             .levels = {
                 .reset = 0,
                 .interrupt = 0,


### PR DESCRIPTION
此问题复现于新版ESP32-S3-Touch-AMOLED-1.75屏幕上，厂商对屏幕触摸做了一次优化。故此加上中断脚。早前更新了触摸组件，新旧开发板不冲突。

tested.
close #1768 