### PR TITLE
fix: fixed ESP32-C6-Touch-AMOLED-2.06 target error

### DIFF
--- a/main/boards/waveshare/esp32-c6-touch-amoled-2.06/config.json
+++ b/main/boards/waveshare/esp32-c6-touch-amoled-2.06/config.json
@@ -1,6 +1,6 @@
 {
     "manufacturer": "waveshare",
-    "target": "esp32s3",
+    "target": "esp32c6",
     "builds": [
         {
             "name": "esp32-c6-touch-amoled-2.06",


### PR DESCRIPTION
修复已知问题
_错误导致：released v.2.2.3ESP32-C6-Touch-AMOLED-2.06固件错误_