### PR TITLE
 Updated AudioService to prevent input task termination on read timeout, introducing a delay instead.

### DIFF
--- a/main/audio/audio_service.cc
+++ b/main/audio/audio_service.cc
@@ -280,8 +280,8 @@ void AudioService::AudioInputTask() {
             }
         }
 
-        ESP_LOGE(TAG, "Should not be here, bits: %lx", bits);
-        break;
+        // Read timeout/error should not terminate the input task.
+        vTaskDelay(pdMS_TO_TICKS(10));
     }
 
     ESP_LOGW(TAG, "Audio input task stopped");
@@ -687,7 +687,10 @@ void AudioService::CheckAndUpdateAudioPowerState() {
         codec_->EnableInput(false);
     }
     if (output_elapsed > AUDIO_POWER_TIMEOUT_MS && codec_->output_enabled()) {
-        codec_->EnableOutput(false);
+        // Keep TX clock when duplex RX is active; otherwise RX may stall on some boards.
+        if (!(codec_->duplex() && codec_->input_enabled())) {
+            codec_->EnableOutput(false);
+        }
     }
     if (!codec_->input_enabled() && !codec_->output_enabled()) {
         esp_timer_stop(audio_power_timer_);

--- a/main/audio/codecs/no_audio_codec.cc
+++ b/main/audio/codecs/no_audio_codec.cc
@@ -239,10 +239,10 @@ int NoAudioCodec::Write(const int16_t* data, int samples) {
 
 int NoAudioCodec::Read(int16_t* dest, int samples) {
     size_t bytes_read;
+    constexpr TickType_t kReadTimeoutTicks = pdMS_TO_TICKS(200);
 
     std::vector<int32_t> bit32_buffer(samples);
-    if (i2s_channel_read(rx_handle_, bit32_buffer.data(), samples * sizeof(int32_t), &bytes_read, portMAX_DELAY) != ESP_OK) {
-        ESP_LOGE(TAG, "Read Failed!");
+    if (i2s_channel_read(rx_handle_, bit32_buffer.data(), samples * sizeof(int32_t), &bytes_read, kReadTimeoutTicks) != ESP_OK) {
         return 0;
     }
 

--- a/main/boards/otto-robot/websocket_control_server.cc
+++ b/main/boards/otto-robot/websocket_control_server.cc
@@ -88,6 +88,7 @@ bool WebSocketControlServer::Start(int port) {
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.server_port = port;
     config.max_open_sockets = 7;
+    config.ctrl_port = 32769;
 
     httpd_uri_t ws_uri = {
         .uri = "/ws",

--- a/main/boards/waveshare/esp32-touch-lcd-3.5/config.json
+++ b/main/boards/waveshare/esp32-touch-lcd-3.5/config.json
@@ -1,4 +1,5 @@
 {
+    "manufacturer": "waveshare",
     "target": "esp32",
     "builds": [
         {


### PR DESCRIPTION
refactor: improve audio service error handling and codec timeout managem…
- Enhanced NoAudioCodec to implement a read timeout for I2S channel reads.
- Adjusted WebSocketControlServer to set a control port for improved socket management.
- Added manufacturer information to the config.json for waveshare ESP32-Touch-LCD-3.5.