### PR TITLE
fix(esp32c5): correct PSRAM configuration

### DIFF
--- a/main/boards/movecall-moji2-esp32c5/config.json
+++ b/main/boards/movecall-moji2-esp32c5/config.json
@@ -7,9 +7,9 @@
                 "CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y",
                 "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/16m.csv\"",
                 "CONFIG_FREERTOS_USE_TICKLESS_IDLE=y",
+                "CONFIG_SPIRAM=y",
                 "CONFIG_SPIRAM_MODE_QUAD=y",
                 "CONFIG_SPIRAM_SPEED_80M=y",
-                "CONFIG_SPIRAM_SPEED=80",
                 "CONFIG_SPI_FLASH_FREQ_LIMIT_C5_240MHZ=y"
             ]
         }


### PR DESCRIPTION
## Summary
Fixes the missing `CONFIG_SPIRAM` enable switch in the ESP32-C5 build configuration.

## Description of Changes
The previous configuration defined the PSRAM speed and mode (Quad/80M) but failed to include `CONFIG_SPIRAM=y`. Without this switch, the PSRAM driver is not compiled, and the memory remains unavailable.

Specific changes:
1.  **Added `CONFIG_SPIRAM=y`**: Explicitly enables PSRAM support.
2.  **Removed `CONFIG_SPIRAM_SPEED=80`**: Cleaned up this redundant integer value as it is automatically handled by `CONFIG_SPIRAM_SPEED_80M=y`.

## Testing
- [x] Build passes for `esp32c5`.