### PR TITLE
Assets 资源管理支持更多的场景

### DIFF
--- a/main/assets.cc
+++ b/main/assets.cc
@@ -50,8 +50,8 @@ bool Assets::FindPartition(Assets* assets) {
     return true;
 }
 
-bool Assets::Apply() {
-    return strategy_ ? strategy_->Apply(this) : false;
+bool Assets::Apply(bool refresh_display_theme) {
+    return strategy_ ? strategy_->Apply(this, refresh_display_theme) : false;
 }
 
 bool Assets::InitializePartition() {
@@ -211,7 +211,7 @@ bool Assets::LvglStrategy::GetAssetData(Assets* assets, const std::string& name,
     return true;
 }
 
-bool Assets::LvglStrategy::Apply(Assets* assets) {
+bool Assets::LvglStrategy::Apply(Assets* assets, bool refresh_display_theme) {
     void* ptr = nullptr;
     size_t size = 0;
     if (!assets->GetAssetData("index.json", ptr, size)) {
@@ -332,22 +332,24 @@ bool Assets::LvglStrategy::Apply(Assets* assets) {
         }
     }
 
-    auto display = Board::GetInstance().GetDisplay();
-    ESP_LOGI(TAG, "Refreshing display theme...");
+    if (refresh_display_theme) {
+        auto display = Board::GetInstance().GetDisplay();
+        ESP_LOGI(TAG, "Refreshing display theme...");
 
-    auto current_theme = display->GetTheme();
-    if (current_theme != nullptr) {
-        display->SetTheme(current_theme);
-    }
+        auto current_theme = display->GetTheme();
+        if (current_theme != nullptr) {
+            display->SetTheme(current_theme);
+        }
 
-    // Parse hide_subtitle configuration
-    cJSON* hide_subtitle = cJSON_GetObjectItem(root, "hide_subtitle");
-    if (cJSON_IsBool(hide_subtitle)) {
-        bool hide = cJSON_IsTrue(hide_subtitle);
-        auto lcd_display = dynamic_cast<LcdDisplay*>(display);
-        if (lcd_display != nullptr) {
-            lcd_display->SetHideSubtitle(hide);
-            ESP_LOGI(TAG, "Set hide_subtitle to %s", hide ? "true" : "false");
+        // Parse hide_subtitle configuration
+        cJSON* hide_subtitle = cJSON_GetObjectItem(root, "hide_subtitle");
+        if (cJSON_IsBool(hide_subtitle)) {
+            bool hide = cJSON_IsTrue(hide_subtitle);
+            auto lcd_display = dynamic_cast<LcdDisplay*>(display);
+            if (lcd_display != nullptr) {
+                lcd_display->SetHideSubtitle(hide);
+                ESP_LOGI(TAG, "Set hide_subtitle to %s", hide ? "true" : "false");
+            }
         }
     }
     
@@ -411,7 +413,7 @@ bool Assets::EmoteStrategy::GetAssetData(Assets* assets, const std::string& name
     return false;
 }
 
-bool Assets::EmoteStrategy::Apply(Assets* assets) {
+bool Assets::EmoteStrategy::Apply(Assets* assets, bool refresh_display_theme) {
     Assets::LoadSrmodelsFromIndex(assets);
 
     auto display = Board::GetInstance().GetDisplay();

--- a/main/assets.h
+++ b/main/assets.h
@@ -29,7 +29,7 @@ public:
     ~Assets();
 
     bool Download(std::string url, std::function<void(int progress, size_t speed)> progress_callback);
-    bool Apply();
+    bool Apply(bool refresh_display_theme = true);
     bool GetAssetData(const std::string& name, void*& ptr, size_t& size);
 
     inline bool partition_valid() const { return partition_valid_; }
@@ -48,7 +48,7 @@ private:
     class AssetStrategy {
     public:
         virtual ~AssetStrategy() = default;
-        virtual bool Apply(Assets* assets) = 0;
+        virtual bool Apply(Assets* assets, bool refresh_display_theme = true) = 0;
         virtual bool InitializePartition(Assets* assets) = 0;
         virtual void UnApplyPartition(Assets* assets) = 0;
         virtual bool GetAssetData(Assets* assets, const std::string& name, void*& ptr, size_t& size) = 0;
@@ -56,7 +56,7 @@ private:
     
     class LvglStrategy : public AssetStrategy {
     public:
-        bool Apply(Assets* assets) override;
+        bool Apply(Assets* assets, bool refresh_display_theme = true) override;
         bool InitializePartition(Assets* assets) override;
         void UnApplyPartition(Assets* assets) override;
         bool GetAssetData(Assets* assets, const std::string& name, void*& ptr, size_t& size) override;
@@ -70,7 +70,7 @@ private:
     
     class EmoteStrategy : public AssetStrategy {
     public:
-        bool Apply(Assets* assets) override;
+        bool Apply(Assets* assets, bool refresh_display_theme = true) override;
         bool InitializePartition(Assets* assets) override;
         void UnApplyPartition(Assets* assets) override;
         bool GetAssetData(Assets* assets, const std::string& name, void*& ptr, size_t& size) override;


### PR DESCRIPTION
支持更多的场景
1. 板子在启动时候需要获取启动画面资源，由于板子还在初始化中，所以会到 assert 获取不到
2. 初始化 LcdDisplay 中获取资源时 DisplayLockGuard lock 会导致重复进入 死锁
3. Apply 函数添加 bool refresh_display_theme = true 参数，保持默认行为，可以支持 板子 在初始化阶段设置为 false 加载 asset 资源