### PR TITLE
Update dependencies in idf_component.yml to latest versions: esp-ml30…

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -23,9 +23,9 @@ dependencies:
   78/esp-wifi-connect: ~3.1.1
   espressif/esp_audio_effects: ~1.2.1
   espressif/esp_audio_codec: ~2.4.1
-  78/esp-ml307: ~3.6.4
+  78/esp-ml307: ~3.6.5
   78/uart-eth-modem:
-    version: ~0.3.3
+    version: ~0.3.4
     rules:
     - if: target not in [esp32]
   78/xiaozhi-fonts: ~1.6.0
@@ -35,7 +35,7 @@ dependencies:
   espressif/button: ~4.1.5
   espressif/knob: ^1.0.0
   espressif/esp32-camera:
-    version: ^2.1.4
+    version: ^2.1.5
     rules:
     - if: target in [esp32s3]
   espressif/esp_video:
@@ -52,18 +52,18 @@ dependencies:
   espressif/esp_lcd_touch_gt1151: ^1
   waveshare/esp_lcd_touch_cst9217: ^1.0.3
   espressif/esp_lcd_touch_cst816s: ^1.0.6
-  lvgl/lvgl: ~9.4.0
-  esp_lvgl_port: ~2.7.0
+  lvgl/lvgl: ~9.5.0
+  esp_lvgl_port: ~2.7.2
   espressif/esp_io_expander_tca95xx_16bit: ^2.0.0
   espressif2022/image_player: ^1.1.1
   espressif2022/esp_emote_expression: ^0.1.0
   espressif/adc_mic: ^0.2.1
-  espressif/esp_mmap_assets: '>=1.2'
+  espressif/esp_mmap_assets: ^1.3.2
   txp666/otto-emoji-gif-component:
     version: ^1.1.1
     rules:
     - if: target in [esp32s3]
-  espressif/adc_battery_estimation: ^0.2.0
+  espressif/adc_battery_estimation: ^0.2.1
   espressif/esp_new_jpeg: ^0.6.1
 
   # SenseCAP Watcher Board

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -20,7 +20,7 @@ dependencies:
   waveshare/custom_io_expander_ch32v003: ^1.0.0
   espressif/esp_lcd_panel_io_additions: ^1.0.1
   78/esp_lcd_nv3023: ~1.0.0
-  78/esp-wifi-connect: ~3.1.1
+  78/esp-wifi-connect: ~3.1.2
   espressif/esp_audio_effects: ~1.2.1
   espressif/esp_audio_codec: ~2.4.1
   78/esp-ml307: ~3.6.5

--- a/partitions/v2/4m.csv
+++ b/partitions/v2/4m.csv
@@ -3,5 +3,5 @@
 nvs,      data, nvs,     0x9000,    0x4000,
 otadata,  data, ota,     0xd000,    0x2000,
 phy_init, data, phy,     0xf000,    0x1000,
-factory,  app,  factory, 0x10000,   0x2CE000,
-assets,   data, spiffs,  0x2DE000,  0x122000,
+factory,  app,  factory, 0x10000,   0x2F0000,
+assets,   data, spiffs,  0x300000,  0x100000,


### PR DESCRIPTION
This pull request primarily updates several dependencies in the `idf_component.yml` file to newer versions and makes adjustments to the partition layout in `partitions/v2/4m.csv`. These changes ensure that the project stays up-to-date with upstream improvements and bug fixes, and also modify the memory allocation for the factory application and assets storage.

**Dependency updates:**

* Updated the following dependencies to newer versions to incorporate bug fixes and improvements:  
  - `78/esp-wifi-connect` to `~3.1.2`  
  - `78/esp-ml307` to `~3.6.5`  
  - `78/uart-eth-modem` to `~0.3.4`  
  - `espressif/esp32-camera` to `^2.1.5`  
  - `lvgl/lvgl` to `~9.5.0` and `esp_lvgl_port` to `~2.7.2`  
  - `espressif/esp_mmap_assets` to `^1.3.2`  
  - `espressif/adc_battery_estimation` to `^0.2.1`

**Partition layout changes:**

* Increased the size of the `factory` application partition and shifted the `assets` partition to start at a higher address with a reduced size in `partitions/v2/4m.csv`, likely to accommodate larger application binaries and optimize storage usage.