### PR TITLE
fix json parse StoreProhibited crash issue

### DIFF
--- a/main/protocols/websocket_protocol.cc
+++ b/main/protocols/websocket_protocol.cc
@@ -147,7 +147,7 @@ bool WebsocketProtocol::OpenAudioChannel() {
             }
         } else {
             // Parse JSON data
-            auto root = cJSON_Parse(data);
+            auto root = cJSON_ParseWithLength(data, len);
             auto type = cJSON_GetObjectItem(root, "type");
             if (cJSON_IsString(type)) {
                 if (strcmp(type->valuestring, "hello") == 0) {
@@ -158,7 +158,7 @@ bool WebsocketProtocol::OpenAudioChannel() {
                     }
                 }
             } else {
-                ESP_LOGE(TAG, "Missing message type, data: %s", data);
+                ESP_LOGE(TAG, "Missing message type, data: %s", std::string(data, len).c_str());
             }
             cJSON_Delete(root);
         }


### PR DESCRIPTION
如果 server 发送的 data 数据，没有 \0 结尾，那么这里是可能出现 StoreProhibited crash 异常的
所以添加

std::string json_str(data, len);

强制  \0 结尾