### PR TITLE
fix(build): 立创实战派 ESP32-S3 摄像头识别与 Windows 构建/烧录（GC2145 勘误）

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@
 # CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
+# ccache on Windows may panic with "Permission denied" (Os error 5) when spawning
+# xtensa-esp-elf-gcc — common with AV/policy. Disable so ninja invokes GCC directly.
+set(CCACHE_ENABLE 0 CACHE BOOL "" FORCE)
+
 # Add this line to disable the specific warning
 add_compile_options(-Wno-missing-field-initializers)
 

--- a/README-Lichuang-S3-Windows.md
+++ b/README-Lichuang-S3-Windows.md
@@ -1,0 +1,83 @@
+# 立创实战派 ESP32-S3 + Windows 构建说明（基于 xiaozhi-esp32）
+
+本文记录针对 **立创实战派 ESP32-S3 开发板** 与 **Windows** 环境所做的排查结论与工程修改，便于复现与向 [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) 提 PR 或自用 Fork。
+
+---
+
+## 1. 摄像头：资料写 GC0308，实际是 GC2145
+
+- 立创实战派 ESP32-S3 部分公开说明/资料标注传感器为 **GC0308**。
+- 实板与串口日志（及 `esp32-camera` 探测）表明 DVP 传感器为 **GC2145**。
+- **xiaozhi** 中 `lichuang-dev` 板级使用 **`Esp32Camera(camera_config_t)` + `esp_camera_init()`**（`espressif/esp32-camera`），由驱动栈自动探测传感器；无需在板级 `config.json` 里写 `CONFIG_CAMERA_GC2145_*`（那是 **esp_video / esp_cam_sensor** 路径的选项）。
+- 若按 GC0308 去改引脚或 menuconfig，容易走偏；以 **GC2145 + 现有 lichuang 引脚与 PCA9557 电源时序** 为准即可。
+
+---
+
+## 2. Windows 下构建/烧录问题与处理
+
+### 2.1 `build_default_assets.py`：`UnicodeDecodeError: 'gbk' codec can't decode...`
+
+- **原因**：Windows 默认文本编码常为 GBK，而 `sdkconfig` 中可能含 UTF-8 注释/字符。
+- **处理**：`scripts/build_default_assets.py` 中增加 **`_read_sdkconfig_lines()`**，以 **二进制读取** `sdkconfig` 再 **`utf-8` + `errors="replace"`** 解码；所有读取 `sdkconfig` 的解析函数改为遍历上述行列表。
+- 顺带：`generate_config_json` 后读回 `config.json`、生成 mmap 头文件等处使用 **`encoding='utf-8'`**。
+
+### 2.2 `ccache`：`Permission denied` / Rust panic（错误 5）
+
+- **现象**：ninja 调用 `ccache` 再启动 `xtensa-esp-elf-gcc` 时，子进程创建被拒绝。
+- **处理**：在根目录 **`CMakeLists.txt`** 中，在 `include(project.cmake)` **之前** 增加：
+
+  `set(CCACHE_ENABLE 0 CACHE BOOL "" FORCE)`
+
+  使编译命令不再经 ccache 包装（若需缓存可自行改回并排除杀软）。向上游提 PR 时可改为 `if(WIN32)` 包裹以不影响 Linux CI。
+
+### 2.3 `xtensa-esp-elf-gcc`：`cannot execute ... cc1.exe` / `CreateProcess: No such file or directory`
+
+- **说明**：`cc1.exe` 在磁盘存在时仍可能因 **VC++ 运行库缺失** 或 **Defender/策略拦截** 报错。
+- **建议**：安装/修复 **Microsoft Visual C++ 2015–2022 Redistributable (x64)**；为 `D:\Espressif\tools\` 加杀毒排除；必要时 `idf.py build -j 1` 降低并行。
+
+### 2.4 烧录：`generated_assets.bin ... will not fit in ... flash`
+
+- **原因**：默认 **`partitions/v2/16m.csv`** 中 **`assets` 分区为 8MB**（起始 `0x800000`），而完整 SR 模型 + 字体 + emoji 等生成的 **`generated_assets.bin` 可达约 11.5MB**。
+- **处理**：在 menuconfig 中将 **Custom partition CSV** 改为 **`partitions/v2/16m_large_assets.csv`**（**单 `ota_0` + 约 12MB `assets`**，无 `ota_1`，失去 A/B 双槽回滚，请自行权衡）。
+- **替代**：不改编分区表，在 **menuconfig** 中减少打包的 Multinet 语言/模型、换更小字体或 emoji，使 `generated_assets.bin` **≤ 8MB**。
+
+---
+
+## 3. 相对上游的改动文件清单
+
+| 文件 | 说明 |
+|------|------|
+| `CMakeLists.txt` | 关闭 `CCACHE_ENABLE`，缓解 Windows 下 ccache 子进程失败 |
+| `scripts/build_default_assets.py` | `sdkconfig`/JSON 等按 UTF-8 安全读取；修正自定义唤醒词解析块缩进 |
+| `partitions/v2/16m_large_assets.csv` | **新增**：16MB Flash、单 OTA、大 assets |
+| `partitions/v2/README.md` | 补充 **`16m_large_assets.csv`** 的说明条目 |
+| `README-Lichuang-S3-Windows.md` | **新增**：本文档 |
+
+---
+
+## 4. 构建与烧录（简要）
+
+```text
+cd D:\esp32\xiaozhi-esp32
+idf.py set-target esp32s3
+idf.py menuconfig   # 选择板型 lichuang-dev；若 assets 过大则换 partitions/v2/16m_large_assets.csv
+idf.py build flash
+```
+
+---
+
+## 5. 许可证与上游
+
+- 上游项目版权仍归 **xiaozhi-esp32** 原作者与许可协议；本文档仅描述补丁与硬件说明勘误。
+- 官方仓库：<https://github.com/78/xiaozhi-esp32>
+
+---
+
+## 6. 提交到本仓库 / Fork 的建议
+
+```bash
+cd D:\esp32\xiaozhi-esp32
+git add CMakeLists.txt scripts/build_default_assets.py partitions/v2/16m_large_assets.csv partitions/v2/README.md README-Lichuang-S3-Windows.md
+git commit -m "fix(win): UTF-8 sdkconfig in build_default_assets, disable ccache; add 16m_large_assets; doc Lichuang S3 GC2145"
+git push
+```

--- a/partitions/v2/16m_large_assets.csv
+++ b/partitions/v2/16m_large_assets.csv
@@ -1,0 +1,10 @@
+# ESP-IDF Partition Table — 16MB Flash, 单 OTA 分区 + 大 assets（约 12MB）
+# 用于 generated_assets.bin > 8MB 时；无 ota_1，失去 A/B 无缝回滚，OTA 仍可向 ota_0 写入。
+# 使用：menuconfig → Partition Table → Custom partition CSV file → partitions/v2/16m_large_assets.csv
+#
+# Name,   Type, SubType, Offset,  Size, Flags
+nvs,      data, nvs,     0x9000,    0x4000,
+otadata,  data, ota,     0xd000,    0x2000,
+phy_init, data, phy,     0xf000,    0x1000,
+ota_0,    app,  ota_0,   0x20000,   0x3f0000,
+assets,   data, spiffs,  0x410000,  12224K

--- a/partitions/v2/README.md
+++ b/partitions/v2/README.md
@@ -57,6 +57,10 @@ The `assets` partition stores:
 - `ota_1`: 4MB
 - `assets`: 8MB
 
+### 16MB Flash Devices (`16m_large_assets.csv`) - Large default assets (Windows / full SR pack)
+- Same `ota_0` size as standard (4MB); **no `ota_1`** (single OTA slot, no A/B rollback).
+- `assets`: ~12MB from `0x410000` to end of flash — use when `generated_assets.bin` exceeds **8MB** (e.g. multiple Multinet models + large fonts/emojis). See `README-Lichuang-S3-Windows.md` in repo root.
+
 ### 16MB Flash Devices (`16m_c3.csv`) - ESP32-C3 Optimized
 - `nvs`: 16KB
 - `otadata`: 8KB

--- a/scripts/build_default_assets.py
+++ b/scripts/build_default_assets.py
@@ -11,13 +11,18 @@ Usage:
 """
 
 import argparse
-import io
 import os
 import shutil
 import sys
 import json
 import struct
 from datetime import datetime
+
+
+def _read_sdkconfig_lines(sdkconfig_path):
+    """Read sdkconfig as raw bytes and decode UTF-8 (avoids Windows default locale / GBK)."""
+    with open(sdkconfig_path, "rb") as f:
+        return f.read().decode("utf-8", errors="replace").splitlines()
 
 
 # =============================================================================
@@ -424,7 +429,7 @@ def pack_assets_simple(target_path, include_path, out_file, assets_path, max_nam
     current_year = datetime.now().year
     asset_name = os.path.basename(assets_path)
     header_file_path = os.path.join(include_path, f'mmap_generate_{asset_name}.h')
-    with open(header_file_path, 'w') as output_header:
+    with open(header_file_path, 'w', encoding='utf-8', newline='\n') as output_header:
         output_header.write('/*\n')
         output_header.write(' * SPDX-FileCopyrightText: 2022-{} Espressif Systems (Shanghai) CO LTD\n'.format(current_year))
         output_header.write(' *\n')
@@ -463,18 +468,17 @@ def read_wakenet_from_sdkconfig(sdkconfig_path):
         return []
         
     models = []
-    with io.open(sdkconfig_path, "r") as f:
-        for label in f:
-            label = label.strip("\n")
-            if 'CONFIG_SR_WN' in label and '#' not in label[0]:
-                if '_NONE' in label:
-                    continue
-                if '=' in label:
-                    label = label.split("=")[0]
-                if '_MULTI' in label:
-                    label = label[:-6]
-                model_name = label.split("_SR_WN_")[-1].lower()
-                models.append(model_name)
+    for label in _read_sdkconfig_lines(sdkconfig_path):
+        label = label.strip("\n")
+        if 'CONFIG_SR_WN' in label and '#' not in label[0]:
+            if '_NONE' in label:
+                continue
+            if '=' in label:
+                label = label.split("=")[0]
+            if '_MULTI' in label:
+                label = label[:-6]
+            model_name = label.split("_SR_WN_")[-1].lower()
+            models.append(model_name)
 
     return models
 
@@ -488,12 +492,11 @@ def read_multinet_from_sdkconfig(sdkconfig_path):
         print(f"Warning: sdkconfig file not found: {sdkconfig_path}")
         return []
         
-    with io.open(sdkconfig_path, "r") as f:
-        models_string = ''
-        for label in f:
-            label = label.strip("\n")
-            if 'CONFIG_SR_MN' in label and label[0] != '#':
-                models_string += label
+    models_string = ''
+    for label in _read_sdkconfig_lines(sdkconfig_path):
+        label = label.strip("\n")
+        if 'CONFIG_SR_MN' in label and label[0] != '#':
+            models_string += label
 
     models = []
     if "CONFIG_SR_MN_CN_MULTINET3_SINGLE_RECOGNITION" in models_string:
@@ -549,22 +552,21 @@ def read_wake_word_type_from_sdkconfig(sdkconfig_path):
         'wake_word_disabled': False
     }
     
-    with io.open(sdkconfig_path, "r") as f:
-        for line in f:
-            line = line.strip("\n")
-            if line.startswith('#'):
-                continue
-                
-            # Check for wake word type configuration
-            if 'CONFIG_USE_ESP_WAKE_WORD=y' in line:
-                config_values['use_esp_wake_word'] = True
-            elif 'CONFIG_USE_AFE_WAKE_WORD=y' in line:
-                config_values['use_afe_wake_word'] = True
-            elif 'CONFIG_USE_CUSTOM_WAKE_WORD=y' in line:
-                config_values['use_custom_wake_word'] = True
-            elif 'CONFIG_WAKE_WORD_DISABLED=y' in line:
-                config_values['wake_word_disabled'] = True
-    
+    for line in _read_sdkconfig_lines(sdkconfig_path):
+        line = line.strip("\n")
+        if line.startswith('#'):
+            continue
+
+        # Check for wake word type configuration
+        if 'CONFIG_USE_ESP_WAKE_WORD=y' in line:
+            config_values['use_esp_wake_word'] = True
+        elif 'CONFIG_USE_AFE_WAKE_WORD=y' in line:
+            config_values['use_afe_wake_word'] = True
+        elif 'CONFIG_USE_CUSTOM_WAKE_WORD=y' in line:
+            config_values['use_custom_wake_word'] = True
+        elif 'CONFIG_WAKE_WORD_DISABLED=y' in line:
+            config_values['wake_word_disabled'] = True
+
     return config_values
 
 
@@ -578,35 +580,34 @@ def read_custom_wake_word_from_sdkconfig(sdkconfig_path):
         return None
         
     config_values = {}
-    with io.open(sdkconfig_path, "r") as f:
-        for line in f:
-            line = line.strip("\n")
-            if line.startswith('#') or '=' not in line:
-                continue
-                
-            # Check for custom wake word configuration
-            if 'CONFIG_USE_CUSTOM_WAKE_WORD=y' in line:
-                config_values['use_custom_wake_word'] = True
-            elif 'CONFIG_CUSTOM_WAKE_WORD=' in line and not line.startswith('#'):
-                # Extract string value (remove quotes)
-                value = line.split('=', 1)[1].strip('"')
-                config_values['wake_word'] = value
-            elif 'CONFIG_CUSTOM_WAKE_WORD_DISPLAY=' in line and not line.startswith('#'):
-                # Extract string value (remove quotes)
-                value = line.split('=', 1)[1].strip('"')
-                config_values['display'] = value
-            elif 'CONFIG_CUSTOM_WAKE_WORD_THRESHOLD=' in line and not line.startswith('#'):
-                # Extract numeric value
-                value = line.split('=', 1)[1]
+    for line in _read_sdkconfig_lines(sdkconfig_path):
+        line = line.strip("\n")
+        if line.startswith('#') or '=' not in line:
+            continue
+
+        # Check for custom wake word configuration
+        if 'CONFIG_USE_CUSTOM_WAKE_WORD=y' in line:
+            config_values['use_custom_wake_word'] = True
+        elif 'CONFIG_CUSTOM_WAKE_WORD=' in line and not line.startswith('#'):
+            # Extract string value (remove quotes)
+            value = line.split('=', 1)[1].strip('"')
+            config_values['wake_word'] = value
+        elif 'CONFIG_CUSTOM_WAKE_WORD_DISPLAY=' in line and not line.startswith('#'):
+            # Extract string value (remove quotes)
+            value = line.split('=', 1)[1].strip('"')
+            config_values['display'] = value
+        elif 'CONFIG_CUSTOM_WAKE_WORD_THRESHOLD=' in line and not line.startswith('#'):
+            # Extract numeric value
+            value = line.split('=', 1)[1]
+            try:
+                config_values['threshold'] = int(value)
+            except ValueError:
                 try:
-                    config_values['threshold'] = int(value)
+                    config_values['threshold'] = float(value)
                 except ValueError:
-                    try:
-                        config_values['threshold'] = float(value)
-                    except ValueError:
-                        print(f"Warning: Invalid threshold value: {value}")
-                        config_values['threshold'] = 20  # default (will be converted to 0.2)
-    
+                    print(f"Warning: Invalid threshold value: {value}")
+                    config_values['threshold'] = 20  # default (will be converted to 0.2)
+
     # Return config only if custom wake word is enabled and required fields are present
     if (config_values.get('use_custom_wake_word', False) and 
         'wake_word' in config_values and 
@@ -777,7 +778,7 @@ def build_assets_integrated(wakenet_model_paths, multinet_model_paths, text_font
         config_path = generate_config_json(temp_build_dir, assets_dir)
         
         # Load config and pack assets
-        with open(config_path, 'r') as f:
+        with open(config_path, 'r', encoding='utf-8', errors='replace') as f:
             config_data = json.load(f)
         
         # Use simplified packing function


### PR DESCRIPTION
## 背景 / Background

**中文（主诉）**  
本 PR 主要面向 **Windows 下使用立创实战派 ESP32-S3 开发板** 时，**摄像头无法被正确识别、进而引发配置/构建/烧录上一系列问题** 的场景。  
根因之一是：**公开资料与部分说明常将传感器标为 GC0308，而大量实板实际为 GC2145**。若按 GC0308 去改引脚或误走其他传感器配置路径，容易导致 **DVP 摄像头初始化失败或表现异常**。  
仓库内 `README-Lichuang-S3-Windows.md` 对 **GC2145 与资料不一致** 作了明确勘误，并说明 **`lichuang-dev` 使用 `esp32-camera` + `esp_camera_init()`**，应与 **`esp_video` / esp_cam_sensor 那套 Kconfig** 区分，避免配错。

**EN (primary intent)**  
This PR primarily addresses **Windows users of the LCSC “Lichuang” ESP32-S3 dev board** where the **camera is not recognized correctly**, which often leads to a **chain of configuration, build, and flashing issues**.  
A common root cause is **documentation listing GC0308 while many shipped boards use GC2145**. Misconfiguring for GC0308 or the wrong camera stack can prevent **DVP camera init** from working.  
`README-Lichuang-S3-Windows.md` documents this **GC2145 vs GC0308** errata and clarifies that **`lichuang-dev` uses `esp32-camera` + `esp_camera_init()`**, distinct from **`esp_video`**-style sensor options.

---

## 工程内附带修复（由上述场景衍生）/ Supporting fixes

在排查 **立创板 + Windows** 过程中，还处理了以下问题（与「摄像头识别」同属一条使用链路上的障碍）：

| 主题 | 说明 |
|------|------|
| **`sdkconfig` 编码** | Windows 默认编码下，`build_default_assets.py` 读 `sdkconfig` 可能 `UnicodeDecodeError`；改为二进制读取后以 UTF-8 安全解码。 |
| **大体积 `generated_assets.bin`** | 默认 16M 分区表中 `assets` 约 8MB 时，完整资源包可能无法烧录；新增可选 `16m_large_assets.csv`（单 `ota_0` + 更大 `assets`，**无 `ota_1`**，已在分区 README 说明取舍）。 |
| **`ccache`** | 部分 Windows 环境经 ccache 调用工具链会失败；根 `CMakeLists.txt` 关闭 `CCACHE_ENABLE`（若维护者要求，可改为仅 `WIN32` 生效）。 |

**EN:** These are **practical blockers on the same Windows + Lichuang workflow** after camera/board bring-up (asset generation, flashing, toolchain). They do not replace the **GC2145 / GC0308** documentation fix above.

---

## 改动文件 / Files

| File | Role |
|------|------|
| `README-Lichuang-S3-Windows.md` | **核心说明**：立创 S3 摄像头与 **GC2145 vs GC0308** 勘误、Windows 构建/烧录注意点。 |
| `scripts/build_default_assets.py` | Windows 下 UTF-8 安全读取 `sdkconfig` 等。 |
| `partitions/v2/16m_large_assets.csv` | 可选大 `assets` 分区。 |
| `partitions/v2/README.md` | 说明新分区表用途与权衡。 |
| `CMakeLists.txt` | 关闭 `ccache` 以缓解 Windows 子进程问题。 |

---

## 测试建议 / Test plan

1. **板级**：立创实战派 S3，`lichuang-dev`，确认摄像头按 **GC2145** 与现有 `esp32-camera` 配置可正常探测/出图（以实板为准）。  
2. **Windows**：`idf.py build` 含默认资源生成；曾触发 GBK/UTF-8 错误的 `sdkconfig` 应不再报错。  
3. **大资源包**：在 menuconfig 中选用 `16m_large_assets.csv` 后整镜像烧录通过。

---

## 合入分支 / Base branch

请维护者指定 **base 分支**（如 `main` 或发布分支）。若需对齐 **v2.2.4** 发布线，可在 PR 讨论中说明由维护者 cherry-pick。
希望合入 2.2.4 维护线 / 请维护者 cherry-pick 到 tag v2.2.4 即可。

---

**Maintainer note:** Hardware errata is documentation-first; code changes focus on **Windows asset pipeline**, **partition option**, and **ccache** reliability on the same workflow.

