### PR TITLE
Remove unused flag for playing popup sound on listening state in Cont…

### DIFF
--- a/main/application.cc
+++ b/main/application.cc
@@ -840,9 +840,6 @@ void Application::ContinueWakeWordInvoke(const std::string& wake_word) {
     }
     // Set the chat state to wake word detected
     protocol_->SendWakeWordDetected(wake_word);
-
-    // Set flag to play popup sound after state changes to listening
-    play_popup_on_listening_ = true;
     SetListeningMode(GetDefaultListeningMode());
 #else
     // Set flag to play popup sound after state changes to listening


### PR DESCRIPTION
This pull request makes a small change to the `Application::ContinueWakeWordInvoke` method by removing the line that sets the `play_popup_on_listening_` flag after a wake word is detected. This simplifies the state transition logic when handling wake word detection.