### PR TITLE
fix: add enable_i2s_on_create option to Es8311AudioCodec for Cardputer Adv

### DIFF
--- a/main/audio/codecs/es8311_audio_codec.cc
+++ b/main/audio/codecs/es8311_audio_codec.cc
@@ -6,7 +6,8 @@
 
 Es8311AudioCodec::Es8311AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port, int input_sample_rate, int output_sample_rate,
     gpio_num_t mclk, gpio_num_t bclk, gpio_num_t ws, gpio_num_t dout, gpio_num_t din,
-    gpio_num_t pa_pin, uint8_t es8311_addr, bool use_mclk, bool pa_inverted) {
+    gpio_num_t pa_pin, uint8_t es8311_addr, bool use_mclk, bool pa_inverted,
+    bool enable_i2s_on_create) {
     duplex_ = true; // 是否双工
     input_reference_ = false; // 是否使用参考输入，实现回声消除
     input_channels_ = 1; // 输入通道数
@@ -17,7 +18,7 @@ Es8311AudioCodec::Es8311AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port,
     input_gain_ = 30;
 
     assert(input_sample_rate_ == output_sample_rate_);
-    CreateDuplexChannels(mclk, bclk, ws, dout, din);
+    CreateDuplexChannels(mclk, bclk, ws, dout, din, enable_i2s_on_create);
 
     // Do initialize of related interface: data_if, ctrl_if and gpio_if
     audio_codec_i2s_cfg_t i2s_cfg = {
@@ -97,7 +98,7 @@ void Es8311AudioCodec::UpdateDeviceState() {
     }
 }
 
-void Es8311AudioCodec::CreateDuplexChannels(gpio_num_t mclk, gpio_num_t bclk, gpio_num_t ws, gpio_num_t dout, gpio_num_t din) {
+void Es8311AudioCodec::CreateDuplexChannels(gpio_num_t mclk, gpio_num_t bclk, gpio_num_t ws, gpio_num_t dout, gpio_num_t din, bool enable_i2s_on_create) {
     assert(input_sample_rate_ == output_sample_rate_);
 
     i2s_chan_config_t chan_cfg = {
@@ -150,8 +151,10 @@ void Es8311AudioCodec::CreateDuplexChannels(gpio_num_t mclk, gpio_num_t bclk, gp
 
     ESP_ERROR_CHECK(i2s_channel_init_std_mode(tx_handle_, &std_cfg));
     ESP_ERROR_CHECK(i2s_channel_init_std_mode(rx_handle_, &std_cfg));
-    ESP_ERROR_CHECK(i2s_channel_enable(tx_handle_));
-    ESP_ERROR_CHECK(i2s_channel_enable(rx_handle_));
+    if (enable_i2s_on_create) {
+        ESP_ERROR_CHECK(i2s_channel_enable(tx_handle_));
+        ESP_ERROR_CHECK(i2s_channel_enable(rx_handle_));
+    }
     ESP_LOGI(TAG, "Duplex channels created");
 }
 

--- a/main/audio/codecs/es8311_audio_codec.h
+++ b/main/audio/codecs/es8311_audio_codec.h
@@ -22,7 +22,7 @@ private:
     bool pa_inverted_ = false;
     std::mutex data_if_mutex_;
 
-    void CreateDuplexChannels(gpio_num_t mclk, gpio_num_t bclk, gpio_num_t ws, gpio_num_t dout, gpio_num_t din);
+    void CreateDuplexChannels(gpio_num_t mclk, gpio_num_t bclk, gpio_num_t ws, gpio_num_t dout, gpio_num_t din, bool enable_i2s_on_create);
     void UpdateDeviceState();
 
     virtual int Read(int16_t* dest, int samples) override;
@@ -31,7 +31,8 @@ private:
 public:
     Es8311AudioCodec(void* i2c_master_handle, i2c_port_t i2c_port, int input_sample_rate, int output_sample_rate,
         gpio_num_t mclk, gpio_num_t bclk, gpio_num_t ws, gpio_num_t dout, gpio_num_t din,
-        gpio_num_t pa_pin, uint8_t es8311_addr, bool use_mclk = true, bool pa_inverted = false);
+        gpio_num_t pa_pin, uint8_t es8311_addr, bool use_mclk = true, bool pa_inverted = false,
+        bool enable_i2s_on_create = true);
     virtual ~Es8311AudioCodec();
 
     virtual void SetOutputVolume(int volume) override;

--- a/main/boards/m5stack-cardputer-adv/m5stack_cardputer_adv.cc
+++ b/main/boards/m5stack-cardputer-adv/m5stack_cardputer_adv.cc
@@ -140,7 +140,9 @@ public:
             AUDIO_I2S_GPIO_DIN,
             AUDIO_CODEC_PA_PIN,
             AUDIO_CODEC_ES8311_ADDR,
-            false);  // use_mclk = false, Cardputer Adv has no MCLK pin
+            false,   // use_mclk = false, Cardputer Adv has no MCLK pin
+            false,   // pa_inverted
+            false);  // enable_i2s_on_create = false, let esp_codec_dev_open manage I2S channels
         return &audio_codec;
     }
 


### PR DESCRIPTION
## Summary

- Fixes #1921 — Cardputer Adv 能配网、能连接控制台，但无法正常对话（麦克风无法收音）

## Root Cause

Commit 9215a04 将 `i2s_channel_enable` 从 `AudioCodec::Start()` 移到了 `Es8311AudioCodec::CreateDuplexChannels()`，使 I2S 通道在构造时就被启用。

对于 Cardputer Adv（无 MCLK，使用内部时钟），I2S 通道在 `esp_codec_dev_open()` 配置 ES8311 之前就已经运行，导致麦克风无法正常工作。

## Fix

给 `Es8311AudioCodec` 构造函数新增 `enable_i2s_on_create` 参数（默认 `true`），完全向后兼容，不影响其他板子：

- **现有板子**：不需要任何改动，行为与之前完全一致
- **Cardputer Adv**：传 `false`，让 `esp_codec_dev_open` 在正确的时机管理 I2S 通道的启用

## Changes

| File | Change |
|------|--------|
| `es8311_audio_codec.h` | 构造函数 + `CreateDuplexChannels` 增加 `enable_i2s_on_create` 参数 |
| `es8311_audio_codec.cc` | 根据参数条件性地调用 `i2s_channel_enable` |
| `m5stack_cardputer_adv.cc` | 传入 `enable_i2s_on_create = false` |

## Test Plan

- [x] Cardputer Adv 麦克风收音功能正常（修复前无法收音，修复后正常对话）
- [ ] 其他 ES8311 板子行为无变化（默认参数 `true`，编译产物一致）