### PR TITLE
fix(waveshare-p4-7b): target v1.x chip rev and 32MB flash layout

### DIFF
--- a/main/boards/esp-p4-function-ev-board/config.json
+++ b/main/boards/esp-p4-function-ev-board/config.json
@@ -9,6 +9,19 @@
                 "CONFIG_ESP_HOSTED_SDIO_HOST_INTERFACE=y",
                 "CONFIG_ESP_HOSTED_SDIO_4_BIT_BUS=y",
                 "CONFIG_SPI_FLASH_SUPPORT_GD_CHIP=y",
+                "CONFIG_BSP_LCD_TYPE_1024_600=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp-p4-function-ev-board-p4x",
+            "sdkconfig_append": [
+                "CONFIG_SLAVE_IDF_TARGET_ESP32C6=y",
+                "CONFIG_ESP_HOSTED_P4_DEV_BOARD_FUNC_BOARD=y",
+                "CONFIG_ESP_HOSTED_SDIO_HOST_INTERFACE=y",
+                "CONFIG_ESP_HOSTED_SDIO_4_BIT_BUS=y",
+                "CONFIG_SPI_FLASH_SUPPORT_GD_CHIP=y",
                 "CONFIG_BSP_LCD_TYPE_1024_600=y"
             ]
         }

--- a/main/boards/m5stack-tab5/config.json
+++ b/main/boards/m5stack-tab5/config.json
@@ -12,6 +12,22 @@
                 "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D0_SLOT_1=11",
                 "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D1_4BIT_BUS_SLOT_1=10",
                 "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D2_4BIT_BUS_SLOT_1=9",
+                "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D3_4BIT_BUS_SLOT_1=8",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "m5stack-tab5-p4x",
+            "sdkconfig_append": [
+                "CONFIG_BOARD_TYPE_M5STACK_CORE_TAB5=y",
+                "CONFIG_CAMERA_SC202CS=y",
+                "CONFIG_XIAOZHI_ENABLE_ROTATE_CAMERA_IMAGE=y",
+                "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CMD_SLOT_1=13",
+                "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_CLK_SLOT_1=12",
+                "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D0_SLOT_1=11",
+                "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D1_4BIT_BUS_SLOT_1=10",
+                "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D2_4BIT_BUS_SLOT_1=9",
                 "CONFIG_ESP_HOSTED_PRIV_SDIO_PIN_D3_4BIT_BUS_SLOT_1=8"
             ]
         }

--- a/main/boards/waveshare/esp32-p4-nano/config.json
+++ b/main/boards/waveshare/esp32-p4-nano/config.json
@@ -9,6 +9,18 @@
                 "CONFIG_CAMERA_OV5647=y",
                 "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
                 "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-nano-10.1-a-p4x",
+            "sdkconfig_append": [
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
                 "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
             ]
         }

--- a/main/boards/waveshare/esp32-p4-wifi6-touch-lcd-3.5/config.json
+++ b/main/boards/waveshare/esp32-p4-wifi6-touch-lcd-3.5/config.json
@@ -10,6 +10,19 @@
                 "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_3_5=y",
                 "CONFIG_CAMERA_OV5647=y",
                 "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-3.5-p4x",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_3_5=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
                 "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
             ]
         }

--- a/main/boards/waveshare/esp32-p4-wifi6-touch-lcd/config.json
+++ b/main/boards/waveshare/esp32-p4-wifi6-touch-lcd/config.json
@@ -13,11 +13,43 @@
                 "CONFIG_CAMERA_OV5647=y",
                 "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
                 "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-4b-p4x",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_4B=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
                 "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
             ]
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-4.3",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_4_3=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-4.3-p4x",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -50,7 +82,40 @@
             ]
         },
         {
+            "name": "esp32-p4-wifi6-touch-lcd-7b-p4x",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_7B=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESPTOOLPY_FLASHSIZE_32MB=y",
+                "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/32m.csv\"",
+                "CONFIG_ESPTOOLPY_FLASH_MODE_AUTO_DETECT=n"
+            ]
+        },
+        {
             "name": "esp32-p4-wifi6-touch-lcd-3.4c",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_3_4C=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-3.4c-p4x",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -74,11 +139,43 @@
                 "CONFIG_CAMERA_OV5647=y",
                 "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
                 "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-4c-p4x",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_4C=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
                 "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
             ]
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-7",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_7=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-7-p4x",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -102,11 +199,43 @@
                 "CONFIG_CAMERA_OV5647=y",
                 "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
                 "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-8-p4x",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_8=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
                 "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
             ]
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-10.1",
+            "sdkconfig_append": [
+                "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
+                "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_P4_WIFI6_TOUCH_LCD_10_1=y",
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_CAMERA_OV5647=y",
+                "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
+                "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "esp32-p4-wifi6-touch-lcd-10.1-p4x",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",

--- a/main/boards/waveshare/esp32-p4-wifi6-touch-lcd/config.json
+++ b/main/boards/waveshare/esp32-p4-wifi6-touch-lcd/config.json
@@ -41,7 +41,12 @@
                 "CONFIG_CAMERA_OV5647=y",
                 "CONFIG_CAMERA_OV5647_AUTO_DETECT_MIPI_INTERFACE_SENSOR=y",
                 "CONFIG_CAMERA_OV5647_MIPI_RAW8_800X800_50FPS=y",
-                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y"
+                "CONFIG_XIAOZHI_ENABLE_CAMERA_ENDIANNESS_SWAP=y",
+                "CONFIG_ESPTOOLPY_FLASHSIZE_32MB=y",
+                "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/32m.csv\"",
+                "CONFIG_ESPTOOLPY_FLASH_MODE_AUTO_DETECT=n",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
             ]
         },
         {

--- a/main/boards/wireless-tag-wtp4c5mp07s/config.json
+++ b/main/boards/wireless-tag-wtp4c5mp07s/config.json
@@ -9,6 +9,19 @@
                 "CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=n",
                 "CONFIG_WIFI_RMT_STATIC_RX_BUFFER_NUM=10",
                 "CONFIG_WIFI_RMT_DYNAMIC_RX_BUFFER_NUM=24",
+                "CONFIG_WIFI_RMT_STATIC_TX_BUFFER_NUM=10",
+                "CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y",
+                "CONFIG_ESP32P4_REV_MIN_100=y"
+            ]
+        },
+        {
+            "name": "wireless-tag-wtp4c5mp07s-p4x",
+            "sdkconfig_append": [
+                "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
+                "CONFIG_SLAVE_IDF_TARGET_ESP32C5=y",
+                "CONFIG_SPIRAM_TRY_ALLOCATE_WIFI_LWIP=n",
+                "CONFIG_WIFI_RMT_STATIC_RX_BUFFER_NUM=10",
+                "CONFIG_WIFI_RMT_DYNAMIC_RX_BUFFER_NUM=24",
                 "CONFIG_WIFI_RMT_STATIC_TX_BUFFER_NUM=10"
             ]
         }


### PR DESCRIPTION
## 概述 / Summary

**中文：**
- 初版修复：Waveshare `ESP32-P4-WIFI6-Touch-LCD-7B` 出厂搭载 **v1.x 版本的 ESP32-P4 硅片**和 **32 MB flash**，但 `config.json` 中的 7B 变体 sdkconfig 既没声明芯片版本，也没声明 flash 大小，IDF 因此默认按 rev v3.1 + 16 MB flash 构建，产出的固件在真实硬件上无法启动。
- 评审后扩展：按 @Y1hsiaochunnn / @laride 的建议，**对所有 P4 board 的 config.json 做"rev<3 默认 + `-p4x` 孪生"拆分**，避免把 `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` 写死在公共 sdkconfig 里影响未来 P4X（rev ≥ 3.x）出货。

**English:**
- Initial fix: the Waveshare `ESP32-P4-WIFI6-Touch-LCD-7B` ships with **v1.x ESP32-P4 silicon** and a **32 MB flash**, but the 7B entry in `config.json` declared neither. IDF then falls back to rev v3.1 + 16 MB defaults, producing firmware that cannot boot on the real hardware.
- After review: per @Y1hsiaochunnn / @laride's suggestion, extend the fix to **every P4 board's `config.json` by splitting each build into an rev<3 default variant and a `-p4x` twin variant**, instead of hard-coding `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` into any shared sdkconfig that would break future P4X (rev ≥ 3.x) hardware.

## 根因 / Root cause

**中文：**
- `ESP32P4_REV_MIN_301` 默认下 bootloader 走 `bootloader.rev3.ld`，被链接到高位 HP_SRAM（`0x4ffa_c2c0` …）。这段地址空间在 v1.x 硅片上不可取指，ROM 加载完 segment 后 jump 过去，CPU 在**第一条指令**就 panic `Guru Meditation Error: Core 0 panic'ed (Illegal instruction)`，bootloader log 一行都打不出来。
- 缺少 `CONFIG_ESPTOOLPY_FLASHSIZE_32MB` 会让 image header 的 flash size 字段错误，超过 16 MB 的分区也无法访问（仅 7B 变体需要）。

**English:**
- With `ESP32P4_REV_MIN_301` the bootloader is linked via `bootloader.rev3.ld` into the upper HP_SRAM window (`0x4ffa_c2c0` …). That range is not fetchable on v1.x silicon; the ROM loads the segments, jumps to `entry`, and the CPU immediately traps with `Guru Meditation Error: Core 0 panic'ed (Illegal instruction)` on the very first opcode — before any bootloader log can be printed.
- Without `CONFIG_ESPTOOLPY_FLASHSIZE_32MB` the image header records the wrong flash size and partitions past 16 MB are unreachable (7B variant only).

## 修复策略 / Fix strategy

**中文 —— 所有 P4 board 的每个 build 拆成两个变体：**
- 原变体（保留原名）添加 `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` + `CONFIG_ESP32P4_REV_MIN_100=y`，对应当前市面主流存量（rev v1.x / v2.x 硅）。
- 新增 `<name>-p4x` 孪生变体，不写上述两行，保持 IDF 默认 `REV_MIN_301`，预留给未来 ESP32-P4X（rev ≥ 3.x）出货。
- 只有 7B 变体额外保留 `CONFIG_ESPTOOLPY_FLASHSIZE_32MB=y` + `partitions/v2/32m.csv` + `CONFIG_ESPTOOLPY_FLASH_MODE_AUTO_DETECT=n`（这是 7B 硬件特有的 32 MB flash 布局），`-p4x` 孪生也复用这套分区。

**English — every build in every P4 config.json is split into two variants:**
- The original variant (same name) gets `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` + `CONFIG_ESP32P4_REV_MIN_100=y`, targeting the current stock of rev v1.x / v2.x silicon.
- A `<name>-p4x` twin is added without those two lines, keeping the IDF default `REV_MIN_301` for future ESP32-P4X (rev ≥ 3.x) hardware.
- Only the 7B variant additionally keeps `CONFIG_ESPTOOLPY_FLASHSIZE_32MB=y` + `partitions/v2/32m.csv` + `CONFIG_ESPTOOLPY_FLASH_MODE_AUTO_DETECT=n` for its specific 32 MB flash layout; the `-p4x` twin carries the same partition config.

## 改动文件 / Files changed

6 个 `config.json`，14 个原 build → 新增 14 个 `-p4x` 孪生，总 28 个 build：
6 `config.json` files, 14 original builds → 14 new `-p4x` twins, 28 total:

| File | 原 build 数 / original | +`-p4x` | 备注 / notes |
|---|---|---|---|
| `main/boards/waveshare/esp32-p4-wifi6-touch-lcd/config.json` | 8 | 8 | 7B 变体保留 32 MB 分区 / 7B variant keeps 32 MB partition |
| `main/boards/waveshare/esp32-p4-wifi6-touch-lcd-3.5/config.json` | 1 | 1 | |
| `main/boards/waveshare/esp32-p4-nano/config.json` | 1 | 1 | |
| `main/boards/esp-p4-function-ev-board/config.json` | 1 | 1 | |
| `main/boards/wireless-tag-wtp4c5mp07s/config.json` | 1 | 1 | |
| `main/boards/m5stack-tab5/config.json` | 1 | 1 | |

未改动 `Kconfig.projbuild` / CMake / README —— `-p4x` 孪生沿用原变体的 `BOARD_TYPE_*=y`，仅 sdkconfig 差异。
No changes to `Kconfig.projbuild` / CMake / README — `-p4x` twins reuse the original variant's `BOARD_TYPE_*=y`, only sdkconfig differs.

## 测试 / Test plan

在一台 Waveshare `ESP32-P4-WIFI6-Touch-LCD-7B`（chip revision v1.3，MAC `80:f1:b2:d3:2a:4e`）上，基于本分支 + `esp-idf v5.5.4` 验证 **原变体 `esp32-p4-wifi6-touch-lcd-7b`**：
Verified on a Waveshare `ESP32-P4-WIFI6-Touch-LCD-7B` (chip revision v1.3, MAC `80:f1:b2:d3:2a:4e`), built from this branch against `esp-idf v5.5.4` using the **original `esp32-p4-wifi6-touch-lcd-7b` variant**:

- [x] Bootloader 段加载到 `0x4ff33ce0 / 0x4ff29ed0 / 0x4ff2cbd0`（与出厂固件一致），不再 panic / Bootloader segments load to `0x4ff33ce0 / 0x4ff29ed0 / 0x4ff2cbd0` (matching factory firmware), no panic
- [x] MIPI-DSI LCD + LVGL 初始化成功，背光 75%
- [x] GT911 触控在地址 `0x5D` 探测正常 / GT911 touch controller probed on `0x5D`
- [x] OV5647 摄像头 (MIPI-CSI) 识别 / OV5647 camera detected
- [x] ES8311 + ES7210 四麦阵列音频初始化 OK / ES8311 playback + ES7210 4-mic array init OK
- [x] ESP32-C6 Wi-Fi6 协处理器通过 SDIO 起来，上报 WLAN + BLE 能力 / ESP32-C6 Wi-Fi6 coprocessor up over SDIO, reports WLAN + BLE capabilities
- [x] MCP 工具（扬声器/屏幕/摄像头/...）注册完成 / MCP tools (speaker/screen/camera/...) registered
- [x] 状态机 `starting → wifi_configuring`，对外暴露 `Xiaozhi-XXXX` 配网热点 / State machine transitions `starting → wifi_configuring`, device exposes the `Xiaozhi-XXXX` provisioning AP

`-p4x` 孪生变体因无 rev ≥ 3.x 实板，只通过 `python scripts/release.py all` 编译验证；待 P4X 出货后由持有板子的开发者回报。
The `-p4x` twin variants cannot be bring-up-tested without rev ≥ 3.x silicon; only compile-verified via `python scripts/release.py all`. On-hardware validation will come from whoever gets P4X sample boards first.

构建命令 / Build command:

```
# rev<3 (current stock)
python scripts/release.py waveshare/esp32-p4-wifi6-touch-lcd --name esp32-p4-wifi6-touch-lcd-7b

# rev>=3 (future P4X)
python scripts/release.py waveshare/esp32-p4-wifi6-touch-lcd --name esp32-p4-wifi6-touch-lcd-7b-p4x
```