### PR TITLE
Add board support for LCDWIKI ES3C28P 2.8-inch ESP32-S3 display

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -785,6 +785,12 @@ elseif(CONFIG_BOARD_TYPE_AI_VOX3)
     set(BUILTIN_TEXT_FONT font_puhui_basic_20_4)
     set(BUILTIN_ICON_FONT font_awesome_20_4)
     set(DEFAULT_EMOJI_COLLECTION twemoji_64)
+elseif(CONFIG_BOARD_TYPE_ES3C28P)
+    set(BOARD_TYPE "es3c28p")
+    set(BUILTIN_TEXT_FONT font_puhui_basic_20_4)
+    set(BUILTIN_ICON_FONT font_awesome_20_4)
+    set(DEFAULT_EMOJI_COLLECTION twemoji_64)
+
 endif()
 
 if(MANUFACTURER)

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -548,6 +548,10 @@ choice BOARD_TYPE
     config BOARD_TYPE_AI_VOX3
         bool "NULLLAB-AI-VOX3"
         depends on IDF_TARGET_ESP32S3
+    config BOARD_TYPE_ES3C28P
+        bool "ES3C28P (LCDWIKI 2.8-inch ESP32-S3 Display)"
+        depends on IDF_TARGET_ESP32S3
+
 endchoice
 
 choice

--- a/main/boards/es3c28p/README.md
+++ b/main/boards/es3c28p/README.md
@@ -1,0 +1,146 @@
+# ES3C28P — 2.8" ESP32-S3 Display Board (XiaoZhi Board Support)
+
+Manufacturer: **LCDWIKI / QDtech (ShenZhen QDtech Electronic Technology Co., Ltd.)**  
+Product page: https://www.lcdwiki.com/2.8inch_ESP32-S3_Display
+
+## Hardware Summary
+
+| Component | Details |
+|-----------|---------|
+| MCU | ESP32-S3-WROOM-1 (N16R8) — 16 MB Flash, 8 MB OPI PSRAM |
+| Display | 2.8" IPS TFT, 240×320, ILI9341V driver, 4-wire SPI |
+| Touch | FT6336G capacitive, I2C |
+| Audio codec | ES8311 (I2C control + I2S data) |
+| Microphone | Single MEMS mic, I2S input |
+| Speaker amp | FM8002E (enable active LOW on GPIO1) |
+| RGB LED | Single WS2812 on GPIO42 |
+| SD card | SDIO (not configured in this board support) |
+| USB | GPIO19 (D−) / GPIO20 (D+) |
+| Power | USB Type-C + external LiPo via TP4054 charger |
+
+## Pin Mapping
+
+### TFT Display (ILI9341V)
+| Signal | GPIO |
+|--------|------|
+| SCK    | 12   |
+| MOSI   | 11   |
+| MISO   | 13   |
+| CS     | 10   |
+| DC/RS  | 46   |
+| BL     | 45   |
+| RST    | shared with CHIP_PU — not driven by firmware |
+
+### Capacitive Touch (FT6336G)
+| Signal | GPIO |
+|--------|------|
+| SDA    | 16 (shared with ES8311 I2C) |
+| SCL    | 15 (shared with ES8311 I2C) |
+| INT    | 17   |
+| RST    | 18   |
+
+### Audio (ES8311 + FM8002E)
+| Signal | GPIO |
+|--------|------|
+| PA EN  | 1 (LOW = enabled) |
+| MCLK   | 4    |
+| BCLK   | 5    |
+| DOUT   | 6 (to speaker) |
+| WS/LR  | 7    |
+| DIN    | 8 (from mic) |
+| I2C SDA| 16   |
+| I2C SCL| 15   |
+
+### Other
+| Component | GPIO |
+|-----------|------|
+| RGB LED   | 42   |
+| BOOT btn  | 0    |
+
+## Build Instructions
+
+### Prerequisites
+- ESP-IDF v5.3 or later
+- Python 3 with `idf_component_manager`
+
+### Steps
+
+```bash
+# 1. Clone the XiaoZhi repo
+git clone https://github.com/78/xiaozhi-esp32.git
+cd xiaozhi-esp32
+
+# 2. Copy this board directory into the boards folder
+cp -r /path/to/es3c28p main/boards/es3c28p
+
+# 3. Add the board entry to main/Kconfig.projbuild
+#    (see "Kconfig entry" section below)
+
+# 4. Set up ESP-IDF environment
+. $IDF_PATH/export.sh   # Linux/macOS
+# or: %IDF_PATH%\export.bat  (Windows)
+
+# 5. Configure — select "ES3C28P" as Board Type
+idf.py menuconfig
+
+# 6. Build
+idf.py build
+
+# 7. Flash (replace /dev/ttyUSB0 with your port)
+idf.py -p /dev/ttyUSB0 flash monitor
+```
+
+Alternatively, use the release script to produce a flashable zip:
+```bash
+python scripts/release.py main/boards/es3c28p
+```
+
+## Kconfig Entry
+
+Add the following block inside the `choice BOARD_TYPE` section in
+`main/Kconfig.projbuild`:
+
+```kconfig
+config BOARD_TYPE_ES3C28P
+    bool "ES3C28P (LCDWIKI 2.8\" ESP32-S3 Display Board)"
+    help
+        LCDWIKI / QDtech ES3C28P — 2.8-inch IPS TFT (ILI9341V),
+        capacitive touch (FT6336G), ES8311 audio codec, single MEMS
+        microphone, FM8002E speaker amplifier, WS2812 RGB LED.
+```
+
+And in `main/CMakeLists.txt`, inside the board-type conditional block, add:
+```cmake
+elseif(CONFIG_BOARD_TYPE_ES3C28P)
+    list(APPEND BOARD_SRCS "boards/es3c28p/es3c28p_board.cc")
+    set(BOARD_NAME "es3c28p")
+```
+
+## First Boot
+
+1. Flash the firmware.
+2. On first boot the board starts a Wi-Fi AP named **XiaoZhi-XXXXXX**.
+3. Connect your phone/PC to that AP and enter your Wi-Fi credentials.
+4. After connecting, a 6-digit device code appears on screen.
+5. Register at [xiaozhi.me](https://xiaozhi.me) and add the device using that code.
+6. Default wake word: **"你好小智"** (configurable).
+
+## Known Limitations / Notes
+
+- **Display RST** is tied to CHIP_PU (hardware reset). The firmware skips
+  driving a software reset pin (`GPIO_NUM_NC`). This is intentional and safe.
+- **PA active-LOW**: The FM8002E amplifier on this board enables on a LOW
+  signal (GPIO1). The `Es8311AudioCodec` constructor's last boolean argument
+  (`false`) sets this polarity.
+- **Shared I2C bus**: GPIO15/16 serve both ES8311 and FT6336G. Both devices
+  have different I2C addresses so they coexist without conflict.
+- **SD card**: SDIO pins (DAT0-DAT3, CMD, CLK) are not configured in this
+  board support. Adding SD support requires additional driver code.
+- **OPI PSRAM pins** (GPIO26, 28, 30, 31, 32) are reserved internally by the
+  ESP-IDF and must not be used by application code.
+
+## References
+
+- [LCDWIKI product page](https://www.lcdwiki.com/2.8inch_ESP32-S3_Display)
+- [XiaoZhi custom board guide](https://github.com/78/xiaozhi-esp32/blob/main/docs/custom-board.md)
+- [ngttai BSP for ES3C28P](https://github.com/ngttai/esp32_s3_es3c28p)

--- a/main/boards/es3c28p/config.h
+++ b/main/boards/es3c28p/config.h
@@ -1,0 +1,52 @@
+#ifndef _BOARD_CONFIG_H_
+#define _BOARD_CONFIG_H_
+
+#include <driver/gpio.h>
+
+#define AUDIO_INPUT_SAMPLE_RATE  24000
+#define AUDIO_OUTPUT_SAMPLE_RATE 24000
+
+// Audio I2S
+#define AUDIO_I2S_GPIO_MCLK      GPIO_NUM_4
+#define AUDIO_I2S_GPIO_BCLK      GPIO_NUM_5
+#define AUDIO_I2S_GPIO_DIN       GPIO_NUM_6   // Data out to speaker
+#define AUDIO_I2S_GPIO_WS        GPIO_NUM_7   // LR clock
+#define AUDIO_I2S_GPIO_DOUT      GPIO_NUM_8   // Data in from mic
+#define AUDIO_CODEC_PA_PIN       GPIO_NUM_1   // Amp enable (active LOW)
+
+// Audio I2C (shared with touch)
+#define AUDIO_CODEC_I2C_NUM      I2C_NUM_0
+#define AUDIO_CODEC_I2C_SCL_PIN  GPIO_NUM_15
+#define AUDIO_CODEC_I2C_SDA_PIN  GPIO_NUM_16
+#define AUDIO_CODEC_ES8311_ADDR  ES8311_CODEC_DEFAULT_ADDR
+
+// Buttons & LED
+#define BOOT_BUTTON_GPIO         GPIO_NUM_0
+#define BUILTIN_LED_GPIO         GPIO_NUM_42
+
+// Display SPI (ILI9341V)
+#define DISPLAY_BACKLIGHT_PIN    GPIO_NUM_45
+#define DISPLAY_RST_PIN          GPIO_NUM_NC
+#define DISPLAY_SCK_PIN          GPIO_NUM_12
+#define DISPLAY_DC_PIN           GPIO_NUM_46
+#define DISPLAY_CS_PIN           GPIO_NUM_10
+#define DISPLAY_MOSI_PIN         GPIO_NUM_11
+#define DISPLAY_MIS0_PIN         GPIO_NUM_13
+#define DISPLAY_SPI_SCLK_HZ      (20 * 1000 * 1000)
+
+#define LCD_SPI_HOST             SPI3_HOST
+
+#define LCD_TYPE_ILI9341_SERIAL
+#define DISPLAY_WIDTH            320
+#define DISPLAY_HEIGHT           240
+#define DISPLAY_MIRROR_X         false
+#define DISPLAY_MIRROR_Y         false
+#define DISPLAY_SWAP_XY          true
+#define DISPLAY_INVERT_COLOR     true
+#define DISPLAY_RGB_ORDER        LCD_RGB_ELEMENT_ORDER_BGR
+#define DISPLAY_OFFSET_X         0
+#define DISPLAY_OFFSET_Y         0
+#define DISPLAY_BACKLIGHT_OUTPUT_INVERT false
+#define DISPLAY_SPI_MODE         0
+
+#endif // _BOARD_CONFIG_H_

--- a/main/boards/es3c28p/config.json
+++ b/main/boards/es3c28p/config.json
@@ -1,0 +1,15 @@
+{
+  "target": "esp32s3",
+  "builds": [
+    {
+      "name": "es3c28p",
+      "sdkconfig_append": [
+        "CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y",
+        "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/16m.csv\"",
+        "CONFIG_ESP_DEFAULT_CPU_FREQ_MHZ_240=y",
+        "CONFIG_SPIRAM_MODE_OCT=y",
+        "CONFIG_SPIRAM_SPEED_80M=y"
+      ]
+    }
+  ]
+}

--- a/main/boards/es3c28p/es3c28p_board.cc
+++ b/main/boards/es3c28p/es3c28p_board.cc
@@ -1,0 +1,251 @@
+#include <esp_lcd_panel_vendor.h>
+#include <esp_lcd_panel_io.h>
+#include <esp_lcd_panel_ops.h>
+
+#include <wifi_station.h>
+#include "wifi_board.h"
+#include "codecs/es8311_audio_codec.h"
+#include "display/lcd_display.h"
+#include "application.h"
+#include "button.h"
+#include "config.h"
+#include "mcp_server.h"
+#include "power_manager.h"
+
+#include <esp_log.h>
+#include <driver/i2c_master.h>
+#include <driver/spi_common.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+#include <esp_timer.h>
+
+#include "led/single_led.h"
+#include "system_reset.h"
+#include "esp_lcd_ili9341.h"
+
+#define TAG "ES3C28PBoard"
+
+// GPIO9 = ADC1 channel 8 on ESP32-S3
+#define BATTERY_ADC_CHANNEL     ADC_CHANNEL_8
+
+class TouchDriver {
+public:
+    TouchDriver() : dev_(nullptr) {}
+
+    bool Init(i2c_master_bus_handle_t bus, uint8_t addr) {
+        i2c_device_config_t cfg = {
+            .device_address = addr,
+            .scl_speed_hz = 400000,
+            .scl_wait_us = 0,
+        };
+        return i2c_master_bus_add_device(bus, &cfg, &dev_) == ESP_OK;
+    }
+
+    bool Read(bool &touched, uint16_t &x, uint16_t &y) {
+        touched = false;
+        x = y = 0;
+        if (!dev_) return false;
+
+        uint8_t reg = 0x02;
+        uint8_t buf[5];
+        if (i2c_master_transmit_receive(dev_, &reg, 1, buf, 5, 50) != ESP_OK) return false;
+
+        uint8_t points = buf[0] & 0x0F;
+        if (points == 0) return true;
+
+        touched = true;
+        x = ((buf[1] & 0x0F) << 8) | buf[2];
+        y = ((buf[3] & 0x0F) << 8) | buf[4];
+        return true;
+    }
+
+private:
+    i2c_master_dev_handle_t dev_;
+};
+
+class ES3C28PBoard : public WifiBoard {
+private:
+    Button boot_button_;
+    LcdDisplay *display_;
+    i2c_master_bus_handle_t codec_i2c_bus_;
+    TouchDriver touch_;
+    PowerManager *power_manager_ = nullptr;
+
+    static void TouchTask(void *arg) {
+        auto *self = static_cast<ES3C28PBoard*>(arg);
+        auto &app = Application::GetInstance();
+
+        uint32_t last_tap = 0;
+        uint32_t down_start = 0;
+        bool down = false;
+
+        while (true) {
+            bool t;
+            uint16_t x, y;
+            self->touch_.Read(t, x, y);
+
+            uint32_t now = esp_timer_get_time() / 1000;
+
+            if (t) {
+                if (!down) {
+                    down = true;
+                    down_start = now;
+                }
+            }
+
+            if (!t && down) {
+                down = false;
+                uint32_t press = now - down_start;
+
+                if (press > 3000) {
+                    self->EnterWifiConfigMode();
+                } else {
+                    if (now - last_tap < 250) {
+                        app.StartListening();
+                        last_tap = 0;
+                    } else {
+                        app.ToggleChatState();
+                        last_tap = now;
+                    }
+                }
+            }
+
+            vTaskDelay(pdMS_TO_TICKS(50));
+        }
+    }
+
+    void InitializeTouch() {
+        if (!touch_.Init(codec_i2c_bus_, 0x38)) return;
+        xTaskCreatePinnedToCore(TouchTask, "touch_task", 4096, this, 5, nullptr, 0);
+    }
+
+    void InitializeI2c() {
+        i2c_master_bus_config_t i2c_bus_cfg = {
+            .i2c_port = AUDIO_CODEC_I2C_NUM,
+            .sda_io_num = AUDIO_CODEC_I2C_SDA_PIN,
+            .scl_io_num = AUDIO_CODEC_I2C_SCL_PIN,
+            .clk_source = I2C_CLK_SRC_DEFAULT,
+            .glitch_ignore_cnt = 7,
+            .intr_priority = 0,
+            .trans_queue_depth = 0,
+            .flags = {
+                .enable_internal_pullup = 1,
+            },
+        };
+        ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_bus_cfg, &codec_i2c_bus_));
+    }
+
+    void InitializeSpi() {
+        spi_bus_config_t buscfg = {};
+        buscfg.mosi_io_num = DISPLAY_MOSI_PIN;
+        buscfg.miso_io_num = DISPLAY_MIS0_PIN;
+        buscfg.sclk_io_num = DISPLAY_SCK_PIN;
+        buscfg.quadwp_io_num = GPIO_NUM_NC;
+        buscfg.quadhd_io_num = GPIO_NUM_NC;
+        buscfg.max_transfer_sz = DISPLAY_WIDTH * DISPLAY_HEIGHT * sizeof(uint16_t);
+        ESP_ERROR_CHECK(spi_bus_initialize(LCD_SPI_HOST, &buscfg, SPI_DMA_CH_AUTO));
+    }
+
+    void InitializeButtons() {
+        boot_button_.OnClick([this]() {
+            auto &app = Application::GetInstance();
+            if (app.GetDeviceState() == kDeviceStateStarting) {
+                EnterWifiConfigMode();
+            }
+            app.ToggleChatState();
+        });
+    }
+
+    void InitializeLcdDisplay() {
+        esp_lcd_panel_io_handle_t panel_io = nullptr;
+        esp_lcd_panel_handle_t panel = nullptr;
+
+        esp_lcd_panel_io_spi_config_t io_config = {};
+        io_config.cs_gpio_num = DISPLAY_CS_PIN;
+        io_config.dc_gpio_num = DISPLAY_DC_PIN;
+        io_config.spi_mode = DISPLAY_SPI_MODE;
+        io_config.pclk_hz = DISPLAY_SPI_SCLK_HZ;
+        io_config.trans_queue_depth = 10;
+        io_config.lcd_cmd_bits = 8;
+        io_config.lcd_param_bits = 8;
+        ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi(LCD_SPI_HOST, &io_config, &panel_io));
+
+        esp_lcd_panel_dev_config_t panel_config = {};
+        panel_config.reset_gpio_num = DISPLAY_RST_PIN;
+        panel_config.rgb_ele_order = DISPLAY_RGB_ORDER;
+        panel_config.bits_per_pixel = 16;
+        ESP_ERROR_CHECK(esp_lcd_new_panel_ili9341(panel_io, &panel_config, &panel));
+        ESP_LOGI(TAG, "Install LCD driver ILI9341");
+
+        esp_lcd_panel_reset(panel);
+        esp_lcd_panel_init(panel);
+        esp_lcd_panel_invert_color(panel, DISPLAY_INVERT_COLOR);
+        esp_lcd_panel_swap_xy(panel, DISPLAY_SWAP_XY);
+        esp_lcd_panel_mirror(panel, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y);
+
+        display_ = new SpiLcdDisplay(panel_io, panel,
+            DISPLAY_WIDTH, DISPLAY_HEIGHT,
+            DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y,
+            DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
+    }
+
+    void InitializePowerManager() {
+        power_manager_ = new PowerManager(BATTERY_ADC_CHANNEL);
+        power_manager_->OnLowBatteryStatusChanged([this](bool low) {
+            if (low) {
+                auto& app = Application::GetInstance();
+                app.Alert("Battery", "Low battery!", "sad", "");
+            }
+        });
+    }
+
+    void InitializeTools() {}
+
+public:
+    ES3C28PBoard() : boot_button_(BOOT_BUTTON_GPIO) {
+        InitializeI2c();
+        InitializeSpi();
+        InitializeLcdDisplay();
+        InitializeTouch();
+        InitializeButtons();
+        InitializePowerManager();
+        InitializeTools();
+        GetBacklight()->SetBrightness(100);
+    }
+
+    virtual Led *GetLed() override {
+        static SingleLed led(BUILTIN_LED_GPIO);
+        return &led;
+    }
+
+    virtual AudioCodec* GetAudioCodec() override {
+        static Es8311AudioCodec audio_codec(codec_i2c_bus_, AUDIO_CODEC_I2C_NUM,
+            AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,
+            AUDIO_I2S_GPIO_MCLK, AUDIO_I2S_GPIO_BCLK,
+            AUDIO_I2S_GPIO_WS, AUDIO_I2S_GPIO_DOUT, AUDIO_I2S_GPIO_DIN,
+            AUDIO_CODEC_PA_PIN, AUDIO_CODEC_ES8311_ADDR, true, true);
+        return &audio_codec;
+    }
+
+    virtual Display *GetDisplay() override { return display_; }
+
+    virtual Backlight *GetBacklight() override {
+        static PwmBacklight backlight(DISPLAY_BACKLIGHT_PIN, DISPLAY_BACKLIGHT_OUTPUT_INVERT);
+        return &backlight;
+    }
+
+    virtual bool GetBatteryLevel(int& level, bool& charging, bool& discharging) override {
+        if (!power_manager_) {
+            level = 0;
+            charging = false;
+            discharging = true;
+            return false;
+        }
+        charging = power_manager_->IsCharging();
+        discharging = power_manager_->IsDischarging();
+        level = power_manager_->GetBatteryLevel();
+        return true;
+    }
+};
+
+DECLARE_BOARD(ES3C28PBoard);

--- a/main/boards/es3c28p/power_manager.h
+++ b/main/boards/es3c28p/power_manager.h
@@ -1,0 +1,149 @@
+#pragma once
+#include <vector>
+#include <functional>
+
+#include <esp_timer.h>
+#include <driver/gpio.h>
+#include <esp_adc/adc_oneshot.h>
+#include <esp_log.h>
+
+// ES3C28P battery monitor
+// GPIO9 = ADC1 channel 8, voltage divider on board
+// No charging detection pin exposed on this board
+
+class PowerManager {
+private:
+    esp_timer_handle_t timer_handle_;
+    std::function<void(bool)> on_charging_status_changed_;
+    std::function<void(bool)> on_low_battery_status_changed_;
+
+    std::vector<uint16_t> adc_values_;
+    uint32_t battery_level_ = 0;
+    bool is_low_battery_ = false;
+    int ticks_ = 0;
+    const int kBatteryAdcInterval = 60;
+    const int kBatteryAdcDataCount = 3;
+    const int kLowBatteryLevel = 20;
+
+    adc_oneshot_unit_handle_t adc_handle_;
+    adc_channel_t adc_channel_;
+
+    void CheckBatteryStatus() {
+        if (adc_values_.size() < kBatteryAdcDataCount) {
+            ReadBatteryAdcData();
+            return;
+        }
+        ticks_++;
+        if (ticks_ % kBatteryAdcInterval == 0) {
+            ReadBatteryAdcData();
+        }
+    }
+
+    void ReadBatteryAdcData() {
+        int adc_value;
+        ESP_ERROR_CHECK(adc_oneshot_read(adc_handle_, adc_channel_, &adc_value));
+
+        adc_values_.push_back(adc_value);
+        if (adc_values_.size() > kBatteryAdcDataCount) {
+            adc_values_.erase(adc_values_.begin());
+        }
+        uint32_t average_adc = 0;
+        for (auto value : adc_values_) {
+            average_adc += value;
+        }
+        average_adc /= adc_values_.size();
+
+        // ADC levels for 3.7V LiPo via resistor divider
+        // Adjust these values based on your actual hardware measurements
+        const struct {
+            uint16_t adc;
+            uint8_t level;
+        } levels[] = {
+            {1980, 0},
+            {2081, 20},
+            {2163, 40},
+            {2250, 60},
+            {2340, 80},
+            {2480, 100}
+        };
+
+        if (average_adc < levels[0].adc) {
+            battery_level_ = 0;
+        } else if (average_adc >= levels[5].adc) {
+            battery_level_ = 100;
+        } else {
+            for (int i = 0; i < 5; i++) {
+                if (average_adc >= levels[i].adc && average_adc < levels[i+1].adc) {
+                    float ratio = static_cast<float>(average_adc - levels[i].adc) / 
+                                  (levels[i+1].adc - levels[i].adc);
+                    battery_level_ = levels[i].level + ratio * (levels[i+1].level - levels[i].level);
+                    break;
+                }
+            }
+        }
+
+        if (adc_values_.size() >= kBatteryAdcDataCount) {
+            bool new_low_battery = battery_level_ <= kLowBatteryLevel;
+            if (new_low_battery != is_low_battery_) {
+                is_low_battery_ = new_low_battery;
+                if (on_low_battery_status_changed_) {
+                    on_low_battery_status_changed_(is_low_battery_);
+                }
+            }
+        }
+
+        ESP_LOGI("PowerManager", "ADC: %d avg: %ld level: %ld%%", 
+                 adc_value, average_adc, battery_level_);
+    }
+
+public:
+    PowerManager(adc_channel_t adc_channel) : adc_channel_(adc_channel) {
+        // Timer for periodic battery checks
+        esp_timer_create_args_t timer_args = {
+            .callback = [](void* arg) {
+                static_cast<PowerManager*>(arg)->CheckBatteryStatus();
+            },
+            .arg = this,
+            .dispatch_method = ESP_TIMER_TASK,
+            .name = "battery_check_timer",
+            .skip_unhandled_events = true,
+        };
+        ESP_ERROR_CHECK(esp_timer_create(&timer_args, &timer_handle_));
+        ESP_ERROR_CHECK(esp_timer_start_periodic(timer_handle_, 100000)); // 100ms
+
+        // ADC init
+        adc_oneshot_unit_init_cfg_t init_config = {
+            .unit_id = ADC_UNIT_1,
+            .ulp_mode = ADC_ULP_MODE_DISABLE,
+        };
+        ESP_ERROR_CHECK(adc_oneshot_new_unit(&init_config, &adc_handle_));
+
+        adc_oneshot_chan_cfg_t chan_config = {
+            .atten = ADC_ATTEN_DB_12,
+            .bitwidth = ADC_BITWIDTH_12,
+        };
+        ESP_ERROR_CHECK(adc_oneshot_config_channel(adc_handle_, adc_channel_, &chan_config));
+    }
+
+    ~PowerManager() {
+        if (timer_handle_) {
+            esp_timer_stop(timer_handle_);
+            esp_timer_delete(timer_handle_);
+        }
+        if (adc_handle_) {
+            adc_oneshot_del_unit(adc_handle_);
+        }
+    }
+
+    bool IsCharging() { return false; }   // No charging pin on ES3C28P
+    bool IsDischarging() { return true; }
+    uint8_t GetBatteryLevel() { return battery_level_; }
+
+    void OnLowBatteryStatusChanged(std::function<void(bool)> callback) {
+        on_low_battery_status_changed_ = callback;
+    }
+
+    void OnChargingStatusChanged(std::function<void(bool)> callback) {
+        on_charging_status_changed_ = callback;
+    }
+};

--- a/main/display/lcd_display.cc
+++ b/main/display/lcd_display.cc
@@ -424,6 +424,12 @@ void LcdDisplay::SetupUI() {
     lv_obj_set_style_text_color(battery_label_, lvgl_theme->text_color(), 0);
     lv_obj_set_style_margin_left(battery_label_, lvgl_theme->spacing(2), 0);
 
+    battery_percent_label_ = lv_label_create(right_icons);
+    lv_label_set_text(battery_percent_label_, "");
+    lv_obj_set_style_text_font(battery_percent_label_, &font_puhui_basic_20_4, 0);
+    lv_obj_set_style_text_color(battery_percent_label_, lvgl_theme->text_color(), 0);
+    lv_obj_set_style_margin_left(battery_percent_label_, lvgl_theme->spacing(1), 0);
+
     /* Layer 2: Status bar - for center text labels */
     status_bar_ = lv_obj_create(screen);
     lv_obj_set_size(status_bar_, LV_HOR_RES, LV_SIZE_CONTENT);
@@ -894,6 +900,12 @@ void LcdDisplay::SetupUI() {
     lv_obj_set_style_text_font(battery_label_, icon_font, 0);
     lv_obj_set_style_text_color(battery_label_, lvgl_theme->text_color(), 0);
     lv_obj_set_style_margin_left(battery_label_, lvgl_theme->spacing(2), 0);
+
+    battery_percent_label_ = lv_label_create(right_icons);
+    lv_label_set_text(battery_percent_label_, "");
+    lv_obj_set_style_text_font(battery_percent_label_, &font_puhui_basic_20_4, 0);
+    lv_obj_set_style_text_color(battery_percent_label_, lvgl_theme->text_color(), 0);
+    lv_obj_set_style_margin_left(battery_percent_label_, lvgl_theme->spacing(1), 0);
 
     /* Layer 2: Status bar - for center text labels */
     status_bar_ = lv_obj_create(screen);

--- a/main/display/lvgl_display/lvgl_display.cc
+++ b/main/display/lvgl_display/lvgl_display.cc
@@ -172,6 +172,11 @@ void LvglDisplay::UpdateStatusBar(bool update_all) {
         if (battery_label_ != nullptr && battery_icon_ != icon) {
             battery_icon_ = icon;
             lv_label_set_text(battery_label_, battery_icon_);
+            if (battery_percent_label_ != nullptr) {
+                char buf[8];
+                snprintf(buf, sizeof(buf), "%d%%", battery_level);
+                lv_label_set_text(battery_percent_label_, buf);
+            }
         }
 
         // Check low battery popup only when clock tick event is triggered

--- a/main/display/lvgl_display/lvgl_display.h
+++ b/main/display/lvgl_display/lvgl_display.h
@@ -34,6 +34,7 @@ protected:
     lv_obj_t *notification_label_ = nullptr;
     lv_obj_t *mute_label_ = nullptr;
     lv_obj_t *battery_label_ = nullptr;
+    lv_obj_t *battery_percent_label_ = nullptr;
     lv_obj_t* low_battery_popup_ = nullptr;
     lv_obj_t* low_battery_label_ = nullptr;
     


### PR DESCRIPTION
ESP32-S3 ES3C28P 2.8 TFT Touch

**Manufacturer:** LCDWIKI / QDtech (ShenZhen QDtech Electronic Technology Co., Ltd.)  
**Product page:** https://www.lcdwiki.com/2.8inch_ESP32-S3_Display

## Hardware
- MCU: ESP32-S3-WROOM-1 N16R8 (16MB Flash, 8MB OPI PSRAM)
- Display: 2.8" IPS TFT 240x320 ILI9341V (4-wire SPI)
- Touch: FT6336G capacitive (I2C)
- Audio: ES8311 codec + MEMS microphone + FM8002E amplifier
- LED: WS2812 RGB on GPIO42
- Battery: ADC monitoring on GPIO9 with percentage display
- Power: USB Type-C + LiPo via TP4054 charger

## Features
- Full emotion/face animation UI
- Touch gestures (single tap, double tap, long press)
- Battery percentage shown in status bar
- Low battery alert

## Tested
Fully tested on real hardware with XiaoZhi v2.2.6

## Acknowledgements
- Board implementation based on the pattern from `freenove-esp32s3-display-2.8-lcd` 
  board by the xiaozhi-esp32 community
- Board support files, pin mapping, battery monitoring, and display percentage 
  code developed with assistance from Claude (Anthropic AI)
- Thanks to the xiaozhi-esp32 maintainer @78 and all contributors