### PR TITLE
Feat: Add battery support and small fixes for Freenove 2.8 board

### DIFF
--- a/main/boards/freenove-esp32s3-display-2.8-lcd/ReadMe.md
+++ b/main/boards/freenove-esp32s3-display-2.8-lcd/ReadMe.md
@@ -3,3 +3,5 @@
 [product](https://store.freenove.com/products/fnk0104)
 
 Official github: [freenove-esp32s3-display-2.8-lcd](https://github.com/Freenove/Freenove_ESP32_S3_Display)
+
+Likely the same hardware design as [LCD wiki ES3C28P/ES3N28P](https://www.lcdwiki.com/2.8inch_ESP32-S3_Display)

--- a/main/boards/freenove-esp32s3-display-2.8-lcd/config.json
+++ b/main/boards/freenove-esp32s3-display-2.8-lcd/config.json
@@ -6,7 +6,7 @@
             "sdkconfig_append": [
                 "CONFIG_ESPTOOLPY_FLASHSIZE_16MB=y",
                 "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/16m.csv\"",
-                "CONFIG_LANGUAGE_EN_US=y"
+                "CONFIG_LANGUAGE_EN_US=y",
                 "CONFIG_SR_WN_WN9S_HIESP=y",
                 "CONFIG_SR_WN_WN9_HIESP=y"
             ]

--- a/main/boards/freenove-esp32s3-display-2.8-lcd/freenove-esp32s3-display-2.8-lcd.cc
+++ b/main/boards/freenove-esp32s3-display-2.8-lcd/freenove-esp32s3-display-2.8-lcd.cc
@@ -10,6 +10,7 @@
 #include "button.h"
 #include "config.h"
 #include "mcp_server.h"
+#include "adc_battery_monitor.h"
 
 #include <esp_log.h>
 #include <driver/i2c_master.h>
@@ -65,6 +66,11 @@ private:
     LcdDisplay *display_;
     i2c_master_bus_handle_t codec_i2c_bus_;
     TouchDriver touch_;
+    AdcBatteryMonitor* adc_battery_monitor_;
+
+    void InitializeBatteryMonitor() {
+        adc_battery_monitor_ = new AdcBatteryMonitor(ADC_UNIT_1, ADC_CHANNEL_8, 200000, 200000, GPIO_NUM_NC);
+    }
 
     static void TouchTask(void *arg) {
         auto *self = static_cast<FreenoveESP32S3Display*>(arg);
@@ -197,6 +203,7 @@ public:
     FreenoveESP32S3Display(): boot_button_(BOOT_BUTTON_GPIO)
     {
         InitializeI2c();
+        InitializeBatteryMonitor();
         InitializeSpi();
         InitializeLcdDisplay();
         InitializeTouch();
@@ -223,6 +230,13 @@ public:
     virtual Backlight *GetBacklight() override {
         static PwmBacklight backlight(DISPLAY_BACKLIGHT_PIN, DISPLAY_BACKLIGHT_OUTPUT_INVERT);
         return &backlight;
+    }
+
+    virtual bool GetBatteryLevel(int &level, bool& charging, bool& discharging) override {
+        charging = adc_battery_monitor_->IsCharging();
+        discharging = adc_battery_monitor_->IsDischarging();
+        level = adc_battery_monitor_->GetBatteryLevel();
+        return true;
     }
 };
 


### PR DESCRIPTION
This PR improves the Freenove 2.8 board.

### Changes:

- Add battery level reading.
- Fix one comma in `config.json`.
- Update `README` with a note about possible shared design with ES3C28P/ES3N28P.
