### PR TITLE
Bind Otto MCP responses to originating WebSocket client

### DIFF
--- a/main/boards/otto-robot/otto_robot.cc
+++ b/main/boards/otto-robot/otto_robot.cc
@@ -232,12 +232,6 @@ private:
             ws_control_server_ = nullptr;
             return;
         }
-        // 将 MCP 响应同时广播回连接到 8080 端口的 WebSocket 客户端
-        Application::GetInstance().RegisterMcpBroadcastCallback([this](const std::string& payload) {
-            if (ws_control_server_) {
-                ws_control_server_->BroadcastMessage(payload);
-            }
-        });
     }
 
     void StartNetwork() override {

--- a/main/boards/otto-robot/websocket_control_server.cc
+++ b/main/boards/otto-robot/websocket_control_server.cc
@@ -144,6 +144,20 @@ void WebSocketControlServer::HandleMessage(httpd_req_t *req, const char* data, s
         return;
     }
 
+    int sock_fd = httpd_req_to_sockfd(req);
+    uint64_t client_id = GetClientId(req);
+    if (client_id == 0) {
+        ESP_LOGW(TAG, "Ignoring message from unknown client: %d", sock_fd);
+        cJSON_Delete(root);
+        return;
+    }
+
+    auto response_sender = [sock_fd, client_id](const std::string& payload) {
+        if (WebSocketControlServer::instance_) {
+            WebSocketControlServer::instance_->SendMessage(sock_fd, client_id, payload);
+        }
+    };
+
     // 支持两种格式：
     // 1. 完整格式：{"type":"mcp","payload":{...}}
     // 2. 简化格式：直接是MCP payload对象
@@ -155,13 +169,13 @@ void WebSocketControlServer::HandleMessage(httpd_req_t *req, const char* data, s
         payload = cJSON_GetObjectItem(root, "payload");
         if (payload != nullptr) {
             cJSON_DetachItemViaPointer(root, payload);
-            McpServer::GetInstance().ParseMessage(payload);
+            McpServer::GetInstance().ParseMessage(payload, response_sender);
             cJSON_Delete(payload); 
         }
     } else {
         payload = cJSON_Duplicate(root, 1);
         if (payload != nullptr) {
-            McpServer::GetInstance().ParseMessage(payload);
+            McpServer::GetInstance().ParseMessage(payload, response_sender);
             cJSON_Delete(payload);
         }
     }
@@ -176,8 +190,11 @@ void WebSocketControlServer::HandleMessage(httpd_req_t *req, const char* data, s
 void WebSocketControlServer::AddClient(httpd_req_t *req) {
     int sock_fd = httpd_req_to_sockfd(req);
     if (clients_.find(sock_fd) == clients_.end()) {
-        clients_[sock_fd] = req;
-        ESP_LOGI(TAG, "Client connected: %d (total: %zu)", sock_fd, clients_.size());
+        uint64_t client_id = ++next_client_id_;
+        clients_[sock_fd] = ClientInfo{
+            .client_id = client_id
+        };
+        ESP_LOGI(TAG, "Client connected: %d id=%llu (total: %zu)", sock_fd, (unsigned long long)client_id, clients_.size());
     }
 }
 
@@ -189,6 +206,15 @@ void WebSocketControlServer::RemoveClient(httpd_req_t *req) {
 
 size_t WebSocketControlServer::GetClientCount() const {
     return clients_.size();
+}
+
+uint64_t WebSocketControlServer::GetClientId(httpd_req_t *req) const {
+    int sock_fd = httpd_req_to_sockfd(req);
+    auto it = clients_.find(sock_fd);
+    if (it == clients_.end()) {
+        return 0;
+    }
+    return it->second.client_id;
 }
 
 struct WsBroadcastJob {
@@ -221,30 +247,44 @@ void WebSocketControlServer::BroadcastMessage(const std::string& message) {
         return;
     }
 
-    for (auto& [fd, req] : clients_) {
-        WsBroadcastJob* job = static_cast<WsBroadcastJob*>(malloc(sizeof(WsBroadcastJob)));
-        if (!job) {
-            ESP_LOGE(TAG, "BroadcastMessage: failed to allocate job");
-            continue;
-        }
+    for (auto& [fd, client] : clients_) {
+        SendMessage(fd, client.client_id, message);
+    }
+}
 
-        job->server = server_handle_;
-        job->fd = fd;
-        job->len = message.length();
-        job->payload = static_cast<char*>(malloc(message.length() + 1));
-        if (!job->payload) {
-            ESP_LOGE(TAG, "BroadcastMessage: failed to allocate payload");
-            free(job);
-            continue;
-        }
-        memcpy(job->payload, message.c_str(), message.length());
-        job->payload[message.length()] = '\0';
+void WebSocketControlServer::SendMessage(int sock_fd, uint64_t client_id, const std::string& message) {
+    if (!server_handle_) {
+        return;
+    }
 
-        esp_err_t ret = httpd_queue_work(server_handle_, ws_broadcast_send_job, job);
-        if (ret != ESP_OK) {
-            ESP_LOGE(TAG, "BroadcastMessage: httpd_queue_work failed fd=%d err=%d", fd, ret);
-            free(job->payload);
-            free(job);
-        }
+    auto client = clients_.find(sock_fd);
+    if (client == clients_.end() || client->second.client_id != client_id) {
+        ESP_LOGW(TAG, "Skip send to stale client fd=%d id=%llu", sock_fd, (unsigned long long)client_id);
+        return;
+    }
+
+    WsBroadcastJob* job = static_cast<WsBroadcastJob*>(malloc(sizeof(WsBroadcastJob)));
+    if (!job) {
+        ESP_LOGE(TAG, "SendMessage: failed to allocate job");
+        return;
+    }
+
+    job->server = server_handle_;
+    job->fd = sock_fd;
+    job->len = message.length();
+    job->payload = static_cast<char*>(malloc(message.length() + 1));
+    if (!job->payload) {
+        ESP_LOGE(TAG, "SendMessage: failed to allocate payload");
+        free(job);
+        return;
+    }
+    memcpy(job->payload, message.c_str(), message.length());
+    job->payload[message.length()] = '\0';
+
+    esp_err_t ret = httpd_queue_work(server_handle_, ws_broadcast_send_job, job);
+    if (ret != ESP_OK) {
+        ESP_LOGE(TAG, "SendMessage: httpd_queue_work failed fd=%d err=%d", sock_fd, ret);
+        free(job->payload);
+        free(job);
     }
 }

--- a/main/boards/otto-robot/websocket_control_server.h
+++ b/main/boards/otto-robot/websocket_control_server.h
@@ -3,6 +3,7 @@
 
 #include <esp_http_server.h>
 #include <cJSON.h>
+#include <cstdint>
 #include <string>
 #include <map>
 
@@ -20,16 +21,22 @@ public:
     void BroadcastMessage(const std::string& message);
 
 private:
+    struct ClientInfo {
+        uint64_t client_id;
+    };
+
     httpd_handle_t server_handle_;
-    std::map<int, httpd_req_t*> clients_;
+    std::map<int, ClientInfo> clients_;
+    uint64_t next_client_id_ = 0;
 
     static esp_err_t ws_handler(httpd_req_t *req);
     
     void HandleMessage(httpd_req_t *req, const char* data, size_t len);
     void AddClient(httpd_req_t *req);
     void RemoveClient(httpd_req_t *req);
+    uint64_t GetClientId(httpd_req_t *req) const;
+    void SendMessage(int sock_fd, uint64_t client_id, const std::string& message);
     static WebSocketControlServer* instance_;
 };
 
 #endif // WEBSOCKET_CONTROL_SERVER_H
-

--- a/main/mcp_server.cc
+++ b/main/mcp_server.cc
@@ -318,13 +318,13 @@ void McpServer::AddUserOnlyTool(const std::string& name, const std::string& desc
     AddTool(tool);
 }
 
-void McpServer::ParseMessage(const std::string& message) {
+void McpServer::ParseMessage(const std::string& message, ResponseSender response_sender) {
     cJSON* json = cJSON_Parse(message.c_str());
     if (json == nullptr) {
         ESP_LOGE(TAG, "Failed to parse MCP message: %s", message.c_str());
         return;
     }
-    ParseMessage(json);
+    ParseMessage(json, std::move(response_sender));
     cJSON_Delete(json);
 }
 
@@ -347,7 +347,7 @@ void McpServer::ParseCapabilities(const cJSON* capabilities) {
     }
 }
 
-void McpServer::ParseMessage(const cJSON* json) {
+void McpServer::ParseMessage(const cJSON* json, ResponseSender response_sender) {
     // Check JSONRPC version
     auto version = cJSON_GetObjectItem(json, "jsonrpc");
     if (version == nullptr || !cJSON_IsString(version) || strcmp(version->valuestring, "2.0") != 0) {
@@ -392,7 +392,7 @@ void McpServer::ParseMessage(const cJSON* json) {
         std::string message = "{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{\"tools\":{}},\"serverInfo\":{\"name\":\"" BOARD_NAME "\",\"version\":\"";
         message += app_desc->version;
         message += "\"}}";
-        ReplyResult(id_int, message);
+        ReplyResult(id_int, message, response_sender);
     } else if (method_str == "tools/list") {
         std::string cursor_str = "";
         bool list_user_only_tools = false;
@@ -406,50 +406,58 @@ void McpServer::ParseMessage(const cJSON* json) {
                 list_user_only_tools = with_user_tools->valueint == 1;
             }
         }
-        GetToolsList(id_int, cursor_str, list_user_only_tools);
+        GetToolsList(id_int, cursor_str, list_user_only_tools, response_sender);
     } else if (method_str == "tools/call") {
         if (!cJSON_IsObject(params)) {
             ESP_LOGE(TAG, "tools/call: Missing params");
-            ReplyError(id_int, "Missing params");
+            ReplyError(id_int, "Missing params", response_sender);
             return;
         }
         auto tool_name = cJSON_GetObjectItem(params, "name");
         if (!cJSON_IsString(tool_name)) {
             ESP_LOGE(TAG, "tools/call: Missing name");
-            ReplyError(id_int, "Missing name");
+            ReplyError(id_int, "Missing name", response_sender);
             return;
         }
         auto tool_arguments = cJSON_GetObjectItem(params, "arguments");
         if (tool_arguments != nullptr && !cJSON_IsObject(tool_arguments)) {
             ESP_LOGE(TAG, "tools/call: Invalid arguments");
-            ReplyError(id_int, "Invalid arguments");
+            ReplyError(id_int, "Invalid arguments", response_sender);
             return;
         }
-        DoToolCall(id_int, std::string(tool_name->valuestring), tool_arguments);
+        DoToolCall(id_int, std::string(tool_name->valuestring), tool_arguments, std::move(response_sender));
     } else {
         ESP_LOGE(TAG, "Method not implemented: %s", method_str.c_str());
-        ReplyError(id_int, "Method not implemented: " + method_str);
+        ReplyError(id_int, "Method not implemented: " + method_str, response_sender);
     }
 }
 
-void McpServer::ReplyResult(int id, const std::string& result) {
+void McpServer::SendResponse(const std::string& payload, const ResponseSender& response_sender) {
+    if (response_sender) {
+        response_sender(payload);
+    } else {
+        Application::GetInstance().SendMcpMessage(payload);
+    }
+}
+
+void McpServer::ReplyResult(int id, const std::string& result, const ResponseSender& response_sender) {
     std::string payload = "{\"jsonrpc\":\"2.0\",\"id\":";
     payload += std::to_string(id) + ",\"result\":";
     payload += result;
     payload += "}";
-    Application::GetInstance().SendMcpMessage(payload);
+    SendResponse(payload, response_sender);
 }
 
-void McpServer::ReplyError(int id, const std::string& message) {
+void McpServer::ReplyError(int id, const std::string& message, const ResponseSender& response_sender) {
     std::string payload = "{\"jsonrpc\":\"2.0\",\"id\":";
     payload += std::to_string(id);
     payload += ",\"error\":{\"message\":\"";
     payload += message;
     payload += "\"}}";
-    Application::GetInstance().SendMcpMessage(payload);
+    SendResponse(payload, response_sender);
 }
 
-void McpServer::GetToolsList(int id, const std::string& cursor, bool list_user_only_tools) {
+void McpServer::GetToolsList(int id, const std::string& cursor, bool list_user_only_tools, const ResponseSender& response_sender) {
     const int max_payload_size = 8000;
     std::string json = "{\"tools\":[";
     
@@ -492,7 +500,7 @@ void McpServer::GetToolsList(int id, const std::string& cursor, bool list_user_o
     if (json.back() == '[' && !tools_.empty()) {
         // 如果没有添加任何tool，返回错误
         ESP_LOGE(TAG, "tools/list: Failed to add tool %s because of payload size limit", next_cursor.c_str());
-        ReplyError(id, "Failed to add tool " + next_cursor + " because of payload size limit");
+        ReplyError(id, "Failed to add tool " + next_cursor + " because of payload size limit", response_sender);
         return;
     }
 
@@ -502,10 +510,10 @@ void McpServer::GetToolsList(int id, const std::string& cursor, bool list_user_o
         json += "],\"nextCursor\":\"" + next_cursor + "\"}";
     }
     
-    ReplyResult(id, json);
+    ReplyResult(id, json, response_sender);
 }
 
-void McpServer::DoToolCall(int id, const std::string& tool_name, const cJSON* tool_arguments) {
+void McpServer::DoToolCall(int id, const std::string& tool_name, const cJSON* tool_arguments, ResponseSender response_sender) {
     auto tool_iter = std::find_if(tools_.begin(), tools_.end(), 
                                  [&tool_name](const McpTool* tool) { 
                                      return tool->name() == tool_name; 
@@ -513,7 +521,7 @@ void McpServer::DoToolCall(int id, const std::string& tool_name, const cJSON* to
     
     if (tool_iter == tools_.end()) {
         ESP_LOGE(TAG, "tools/call: Unknown tool: %s", tool_name.c_str());
-        ReplyError(id, "Unknown tool: " + tool_name);
+        ReplyError(id, "Unknown tool: " + tool_name, response_sender);
         return;
     }
 
@@ -537,24 +545,24 @@ void McpServer::DoToolCall(int id, const std::string& tool_name, const cJSON* to
 
             if (!argument.has_default_value() && !found) {
                 ESP_LOGE(TAG, "tools/call: Missing valid argument: %s", argument.name().c_str());
-                ReplyError(id, "Missing valid argument: " + argument.name());
+                ReplyError(id, "Missing valid argument: " + argument.name(), response_sender);
                 return;
             }
         }
     } catch (const std::exception& e) {
         ESP_LOGE(TAG, "tools/call: %s", e.what());
-        ReplyError(id, e.what());
+        ReplyError(id, e.what(), response_sender);
         return;
     }
 
     // Use main thread to call the tool
     auto& app = Application::GetInstance();
-    app.Schedule([this, id, tool_iter, arguments = std::move(arguments)]() {
+    app.Schedule([this, id, tool_iter, arguments = std::move(arguments), response_sender = std::move(response_sender)]() {
         try {
-            ReplyResult(id, (*tool_iter)->Call(arguments));
+            ReplyResult(id, (*tool_iter)->Call(arguments), response_sender);
         } catch (const std::exception& e) {
             ESP_LOGE(TAG, "tools/call: %s", e.what());
-            ReplyError(id, e.what());
+            ReplyError(id, e.what(), response_sender);
         }
     });
 }

--- a/main/mcp_server.h
+++ b/main/mcp_server.h
@@ -313,6 +313,8 @@ public:
 
 class McpServer {
 public:
+    using ResponseSender = std::function<void(const std::string&)>;
+
     static McpServer& GetInstance() {
         static McpServer instance;
         return instance;
@@ -323,8 +325,8 @@ public:
     void AddTool(McpTool* tool);
     void AddTool(const std::string& name, const std::string& description, const PropertyList& properties, std::function<ReturnValue(const PropertyList&)> callback);
     void AddUserOnlyTool(const std::string& name, const std::string& description, const PropertyList& properties, std::function<ReturnValue(const PropertyList&)> callback);
-    void ParseMessage(const cJSON* json);
-    void ParseMessage(const std::string& message);
+    void ParseMessage(const cJSON* json, ResponseSender response_sender = nullptr);
+    void ParseMessage(const std::string& message, ResponseSender response_sender = nullptr);
 
 private:
     McpServer();
@@ -332,11 +334,12 @@ private:
 
     void ParseCapabilities(const cJSON* capabilities);
 
-    void ReplyResult(int id, const std::string& result);
-    void ReplyError(int id, const std::string& message);
+    void SendResponse(const std::string& payload, const ResponseSender& response_sender);
+    void ReplyResult(int id, const std::string& result, const ResponseSender& response_sender);
+    void ReplyError(int id, const std::string& message, const ResponseSender& response_sender);
 
-    void GetToolsList(int id, const std::string& cursor, bool list_user_only_tools);
-    void DoToolCall(int id, const std::string& tool_name, const cJSON* tool_arguments);
+    void GetToolsList(int id, const std::string& cursor, bool list_user_only_tools, const ResponseSender& response_sender);
+    void DoToolCall(int id, const std::string& tool_name, const cJSON* tool_arguments, ResponseSender response_sender);
 
     std::vector<McpTool*> tools_;
 };


### PR DESCRIPTION
Fixes #2020

## Summary
- Add an optional MCP response sender so callers can route replies to a specific transport endpoint.
- Route Otto Robot local WebSocket MCP responses back only to the client that sent the request.
- Remove the Otto MCP response broadcast path that sent tool results to all connected local WebSocket clients.
- Track a per-client generation id to avoid sending delayed async tool responses to a stale/reused socket fd.

## Testing
- `git diff --check`

Firmware build was not run in this environment because `idf.py` is unavailable.