### PR TITLE
Validate MQTT goodbye session IDs

### DIFF
--- a/main/protocols/mqtt_protocol.cc
+++ b/main/protocols/mqtt_protocol.cc
@@ -114,8 +114,8 @@ bool MqttProtocol::StartMqttClient(bool report_error) {
             ParseServerHello(root);
         } else if (strcmp(type->valuestring, "goodbye") == 0) {
             auto session_id = cJSON_GetObjectItem(root, "session_id");
-            ESP_LOGI(TAG, "Received goodbye message, session_id: %s", session_id ? session_id->valuestring : "null");
-            if (session_id == nullptr || session_id_ == session_id->valuestring) {
+            ESP_LOGI(TAG, "Received goodbye message, session_id: %s", cJSON_IsString(session_id) ? session_id->valuestring : "null");
+            if (cJSON_IsString(session_id) && session_id_ == session_id->valuestring) {
                 auto alive = alive_;  // Capture alive flag
                 Application::GetInstance().Schedule([this, alive]() {
                     if (*alive) {


### PR DESCRIPTION
## Summary
- Require MQTT goodbye messages to carry a string session_id
- Only close the audio channel when the goodbye session_id matches the active session
- Prevent sessionless goodbye payloads from terminating active MQTT + UDP audio sessions

Fixes #2022

## Testing
- Built and ran a source-level MQTT protocol harness that directly includes mqtt_protocol.cc/protocol.cc with ESP-IDF/MQTT/UDP stubs
- Verified missing-session goodbye no longer closes the channel
- Verified matching-session goodbye still closes the channel

Harness output after fix:
```text
missing_session_wrong_topic opened_before=1 opened_after=1 closed_count=0
matching_session_wrong_topic opened_before=1 opened_after=0 closed_count=1
wrong_session_wrong_topic opened_before=1 opened_after=1 closed_count=0
non_goodbye_wrong_topic opened_before=1 opened_after=1 closed_count=0
```