### PR TITLE
fix(sensecap-watcher): scale emoji to fill 412x412 round screen

### DIFF
--- a/main/boards/sensecap-watcher/sensecap_watcher.cc
+++ b/main/boards/sensecap-watcher/sensecap_watcher.cc
@@ -99,6 +99,14 @@ class CustomLcdDisplay : public SpiLcdDisplay {
             // 针对圆形屏幕调整底部对话框位置，避免被圆角遮挡
             lv_obj_set_style_pad_bottom(bottom_bar_, 30, 0);
             lv_obj_set_width(chat_message_label_, LV_HOR_RES * 0.75); // 限制宽度，避免文字贴边
+
+            // Scale emoji to fill the 412x412 round screen.
+            // Without this, the default 64px Twemoji images appear as a tiny dot.
+            lvgl_theme->set_emoji_collection(std::make_shared<Twemoji64>());
+            lv_obj_set_size(emoji_box_, LV_HOR_RES, LV_VER_RES);
+            lv_obj_align(emoji_box_, LV_ALIGN_CENTER, 0, 0);
+            lv_image_set_scale(emoji_image_, (lv_coord_t)LV_HOR_RES * 256 / 64);
+            lv_obj_center(emoji_image_);
         }
 };
 


### PR DESCRIPTION
## Problem

The emoji face on the SenseCAP Watcher's 412×412 round display renders as a tiny dot. Three issues compound:

1. **No emoji collection registered** — `SetEmotion()` fell back to a 30px font icon on a 412px screen
2. **`emoji_box_` sized to content** (`LV_SIZE_CONTENT`) — box shrinks to the raw 64px image, making centering meaningless
3. **No scale applied to `emoji_image_`** — `lv_img_create` produces an unscaled widget by default

## Fix

In `CustomLcdDisplay::SetupUI()` inside `main/boards/sensecap-watcher/sensecap_watcher.cc` (board-specific code, no shared files touched):

- Registers `Twemoji64` (64×64px images) as the emoji collection so image-based emojis are used
- Expands `emoji_box_` to `LV_HOR_RES × LV_VER_RES` to cover the full round screen
- Applies `lv_image_set_scale(emoji_image_, 412*256/64 = 1648)` — ~6.4× upscale so the 64px emoji fills the 412px diameter display

The scale persists across `SetEmotion()` calls because `lv_image_set_scale` is a widget property independent of the image source.

## Test plan

- [ ] Build for `sensecap-watcher` target and flash to device
- [ ] Confirm emoji face fills the round display in idle / listening / speaking states
- [ ] Confirm status bar (network, mute, battery) overlays correctly at top
- [ ] Confirm chat subtitle appears correctly at bottom