### PR TITLE
feat(m5stack-cardputer-adv): add battery monitoring support

### DIFF
--- a/main/boards/m5stack-cardputer-adv/README.md
+++ b/main/boards/m5stack-cardputer-adv/README.md
@@ -14,7 +14,7 @@ M5Stack Cardputer Adv 是一款基于 ESP32-S3FN8 (Stamp-S3A) 的卡片式电脑
 | 麦克风 | MEMS |
 | 键盘 | 56键 (TCA8418) |
 | IMU | BMI270 |
-| 电池 | 1750mAh |
+| 电池 | 1750mAh (带ADC电量监测) |
 
 ## 引脚定义
 
@@ -37,6 +37,11 @@ M5Stack Cardputer Adv 是一款基于 ESP32-S3FN8 (Stamp-S3A) 的卡片式电脑
 | I2S LRCK | GPIO43 |
 | I2S DOUT | GPIO46 |
 | I2S DIN | GPIO42 |
+
+### 电池监测
+| 功能 | GPIO | 备注 |
+|------|------|------|
+| ADC | GPIO10 | 100KΩ / 100KΩ 分压 |
 
 ## 使用方法
 

--- a/main/boards/m5stack-cardputer-adv/config.h
+++ b/main/boards/m5stack-cardputer-adv/config.h
@@ -56,4 +56,13 @@
 // IMU BMI270 I2C address
 #define IMU_BMI270_ADDR 0x68
 
+// Battery monitoring (ADC voltage divider on GPIO 10 / ADC1_CH9)
+// Verified from Cardputer-Adv schematic (Sch_M5CardputerAdv_v1.0):
+// R9 = 100KΩ (BAT+ to GPIO10), R8 = 100KΩ (GPIO10 to GND)
+#define BATTERY_ADC_UNIT        ADC_UNIT_1
+#define BATTERY_ADC_CHANNEL     ADC_CHANNEL_9
+#define BATTERY_UPPER_RESISTOR  100000.0f
+#define BATTERY_LOWER_RESISTOR  100000.0f
+#define BATTERY_CHARGING_PIN    GPIO_NUM_NC
+
 #endif // _BOARD_CONFIG_H_

--- a/main/boards/m5stack-cardputer-adv/m5stack_cardputer_adv.cc
+++ b/main/boards/m5stack-cardputer-adv/m5stack_cardputer_adv.cc
@@ -7,6 +7,7 @@
 #include "config.h"
 #include "i2c_device.h"
 #include "tca8418_keyboard.h"
+#include "adc_battery_monitor.h"
 
 #include <esp_log.h>
 #include <driver/i2c_master.h>
@@ -33,6 +34,7 @@ private:
     esp_lcd_panel_io_handle_t panel_io_ = nullptr;
     esp_lcd_panel_handle_t panel_ = nullptr;
     Tca8418Keyboard* keyboard_ = nullptr;
+    AdcBatteryMonitor* battery_monitor_ = nullptr;
     std::unique_ptr<WifiConfigUI> wifi_config_ui_;
     bool wifi_config_mode_ = false;
 
@@ -128,6 +130,15 @@ private:
             }
             app.ToggleChatState();
         });
+    }
+
+    void InitializeBatteryMonitor() {
+        ESP_LOGI(TAG, "Initialize battery monitor (GPIO%d, %dK/%dK divider)",
+                 BATTERY_ADC_CHANNEL, (int)(BATTERY_UPPER_RESISTOR / 1000), (int)(BATTERY_LOWER_RESISTOR / 1000));
+        battery_monitor_ = new AdcBatteryMonitor(
+            BATTERY_ADC_UNIT, BATTERY_ADC_CHANNEL,
+            BATTERY_UPPER_RESISTOR, BATTERY_LOWER_RESISTOR,
+            BATTERY_CHARGING_PIN);
     }
 
     void InitializeKeyboard() {
@@ -317,6 +328,7 @@ public:
         InitializeSt7789Display();
         InitializeButtons();
         InitializeKeyboard();
+        InitializeBatteryMonitor();
         GetBacklight()->RestoreBrightness();
     }
 
@@ -352,6 +364,16 @@ public:
         // M5GFX uses 256Hz PWM frequency for Cardputer backlight
         static PwmBacklight backlight(DISPLAY_BACKLIGHT_PIN, DISPLAY_BACKLIGHT_OUTPUT_INVERT, 256);
         return &backlight;
+    }
+
+    virtual bool GetBatteryLevel(int& level, bool& charging, bool& discharging) override {
+        if (battery_monitor_ == nullptr) {
+            return false;
+        }
+        charging = battery_monitor_->IsCharging();
+        discharging = battery_monitor_->IsDischarging();
+        level = battery_monitor_->GetBatteryLevel();
+        return true;
     }
 };
 


### PR DESCRIPTION
## Summary

Add ADC battery monitoring for the M5Stack Cardputer-Adv board.

## Hardware verification

Verified from official schematic (Sch_M5CardputerAdv_v1.0):
- Battery ADC pin: GPIO10 (ADC1_CH9)
- Voltage divider: R9=100KΩ (BAT+ to GPIO10), R8=100KΩ (GPIO10 to GND)

## Changes

- config.h: add BATTERY_ADC_* defines
- m5stack_cardputer_adv.cc: add AdcBatteryMonitor, override GetBatteryLevel()
- README.md: document battery monitoring pinout

## Impact

Battery level now appears in device status and UI.

Fixes: missing battery level reporting on Cardputer-Adv.