### PR TITLE
feat: Vietnamese firmware build for ESP32-S3-RLCD-4.2

### DIFF
--- a/.github/workflows/build-vi.yml
+++ b/.github/workflows/build-vi.yml
@@ -1,0 +1,147 @@
+name: Build Vietnamese Firmware (RLCD-4.2)
+
+on:
+  push:
+    branches:
+      - main
+      - vi-build-rlcd
+  pull_request:
+    branches:
+      - main
+      - vi-build-rlcd
+  workflow_dispatch:
+    inputs:
+      create_release:
+        description: 'Create a GitHub release after build? (yes/no)'
+        required: false
+        default: 'no'
+      release_tag:
+        description: 'Release tag (e.g. v2.2.6-vi.1). Required if create_release=yes'
+        required: false
+        default: ''
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build esp32-s3-rlcd-4.2-vi
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:v5.5.2
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      artifact_name: ${{ steps.naming.outputs.artifact_name }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Read project version
+        id: version
+        shell: bash
+        run: |
+          VER=$(grep -E '^set\(PROJECT_VER' CMakeLists.txt | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "version=$VER" >> $GITHUB_OUTPUT
+          echo "Building Xiaozhi v$VER (Vietnamese)"
+
+      - name: Compute artifact name
+        id: naming
+        shell: bash
+        run: |
+          NAME="xiaozhi-vi-rlcd-4.2-${GITHUB_SHA::8}"
+          echo "artifact_name=$NAME" >> $GITHUB_OUTPUT
+
+      - name: Build firmware
+        shell: bash
+        run: |
+          source $IDF_PATH/export.sh
+          python scripts/release.py waveshare/esp32-s3-rlcd-4.2 \
+              --name esp32-s3-rlcd-4.2-vi
+
+      - name: Verify build output
+        shell: bash
+        run: |
+          ls -la build/
+          test -f build/merged-binary.bin || { echo "ERROR: merged-binary.bin missing"; exit 1; }
+          SIZE=$(stat -c%s build/merged-binary.bin)
+          SIZE_KB=$((SIZE / 1024))
+          echo "Binary size: ${SIZE_KB} KB"
+          if [ "$SIZE" -lt 1000000 ]; then
+            echo "ERROR: Binary too small (<1MB), likely build incomplete"
+            exit 1
+          fi
+
+      - name: Compute SHA256 checksum
+        shell: bash
+        run: |
+          cd build
+          sha256sum merged-binary.bin > merged-binary.bin.sha256
+          cat merged-binary.bin.sha256
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.naming.outputs.artifact_name }}
+          path: |
+            build/merged-binary.bin
+            build/merged-binary.bin.sha256
+          retention-days: 30
+          if-no-files-found: error
+
+  release-manual:
+    name: Create Release (manual dispatch)
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.create_release == 'yes' && github.event.inputs.release_tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build.outputs.artifact_name }}
+          path: ./release-files
+
+      - name: Rename binary with version
+        shell: bash
+        run: |
+          cd release-files
+          TAG="${{ github.event.inputs.release_tag }}"
+          mv merged-binary.bin "xiaozhi-${TAG}-rlcd-4.2-vi.bin"
+          mv merged-binary.bin.sha256 "xiaozhi-${TAG}-rlcd-4.2-vi.bin.sha256"
+          ls -la
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.release_tag }}
+          name: Xiaozhi ${{ github.event.inputs.release_tag }} (Vietnamese, RLCD-4.2)
+          body: |
+            ## Xiaozhi Vietnamese Firmware
+
+            Auto-built from commit `${{ github.sha }}` via manual dispatch.
+
+            **Target board**: Waveshare ESP32-S3-RLCD-4.2
+            **Language**: Tiếng Việt (vi-VN)
+            **Firmware version**: v${{ needs.build.outputs.version }}
+
+            ### Flash instructions
+
+            ```bash
+            esptool.py --chip esp32s3 --port /dev/cu.usbmodem11301 --baud 115200 \
+                write_flash --no-compress 0x0 xiaozhi-${{ github.event.inputs.release_tag }}-rlcd-4.2-vi.bin
+            ```
+
+            ### Verify checksum
+
+            ```bash
+            sha256sum -c xiaozhi-${{ github.event.inputs.release_tag }}-rlcd-4.2-vi.bin.sha256
+            ```
+          files: |
+            release-files/*.bin
+            release-files/*.sha256
+          draft: false
+          prerelease: false
+          generate_release_notes: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,10 @@
-name: Build Boards
+name: Build All Boards (upstream, manual only)
 
+# Disabled auto-trigger on fork. Original upstream workflow that builds 30+ boards.
+# Use workflow_dispatch to trigger manually if needed.
+# Vietnamese-specific build is in build-vi.yml and release-vi.yml.
 on:
-  push:
-    branches:
-      - main
-      - ci/* # for ci test
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/release-vi.yml
+++ b/.github/workflows/release-vi.yml
@@ -1,0 +1,98 @@
+name: Release Vietnamese Firmware (RLCD-4.2)
+
+on:
+  push:
+    tags:
+      - 'v*-vi*'
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-release:
+    name: Build and release esp32-s3-rlcd-4.2-vi
+    runs-on: ubuntu-latest
+    container:
+      image: espressif/idf:v5.5.2
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Read project version
+        id: version
+        shell: bash
+        run: |
+          VER=$(grep -E '^set\(PROJECT_VER' CMakeLists.txt | sed -E 's/.*"([^"]+)".*/\1/')
+          echo "version=$VER" >> $GITHUB_OUTPUT
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "Building Xiaozhi v$VER for tag $TAG"
+
+      - name: Build firmware
+        shell: bash
+        run: |
+          source $IDF_PATH/export.sh
+          python scripts/release.py waveshare/esp32-s3-rlcd-4.2 \
+              --name esp32-s3-rlcd-4.2-vi
+
+      - name: Verify and rename binary
+        shell: bash
+        run: |
+          test -f build/merged-binary.bin
+          mkdir -p release-files
+          TAG="${{ steps.version.outputs.tag }}"
+          cp build/merged-binary.bin "release-files/xiaozhi-${TAG}-rlcd-4.2-vi.bin"
+          cd release-files
+          sha256sum "xiaozhi-${TAG}-rlcd-4.2-vi.bin" > "xiaozhi-${TAG}-rlcd-4.2-vi.bin.sha256"
+          ls -la
+          cat "xiaozhi-${TAG}-rlcd-4.2-vi.bin.sha256"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: Xiaozhi ${{ steps.version.outputs.tag }} (Vietnamese, RLCD-4.2)
+          body: |
+            ## Xiaozhi Vietnamese Firmware
+
+            Auto-built and released from tag `${{ steps.version.outputs.tag }}` (commit `${{ github.sha }}`).
+
+            **Target board**: Waveshare ESP32-S3-RLCD-4.2
+            **Language**: Tiếng Việt (vi-VN)
+            **Firmware version**: v${{ steps.version.outputs.version }}
+
+            ### Flash instructions
+
+            Download the `.bin` file below, then on macOS:
+
+            ```bash
+            # Cài esptool nếu chưa có
+            pip3 install --break-system-packages esptool
+
+            # Tìm USB port của board
+            ls /dev/cu.usbmodem*
+
+            # Erase + flash
+            esptool.py --chip esp32s3 --port /dev/cu.usbmodemXXXX --baud 460800 erase_flash
+            esptool.py --chip esp32s3 --port /dev/cu.usbmodemXXXX --baud 115200 \
+                write_flash --no-compress 0x0 xiaozhi-${{ steps.version.outputs.tag }}-rlcd-4.2-vi.bin
+            ```
+
+            ### Verify checksum
+
+            ```bash
+            sha256sum -c xiaozhi-${{ steps.version.outputs.tag }}-rlcd-4.2-vi.bin.sha256
+            ```
+
+            ### Note
+
+            - Wake word: `你好小智` (Ni Hao Xiao Zhi) — không đổi được mà không re-train ESP-SR model
+            - LLM response language: cấu hình trên https://xiaozhi.me dashboard
+          files: |
+            release-files/xiaozhi-*.bin
+            release-files/xiaozhi-*.bin.sha256
+          draft: false
+          prerelease: false
+          generate_release_notes: true

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,0 +1,88 @@
+# xiaozhi-esp32-vi 🇻🇳
+
+Fork của [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32) với:
+
+- 🇻🇳 **Tiếng Việt làm UI mặc định** (locale vi-VN có sẵn từ upstream)
+- 🎯 **Target board**: Waveshare ESP32-S3-RLCD-4.2
+- 🤖 **Auto-build firmware** qua GitHub Actions
+
+## Tải firmware
+
+- **Latest release**: [Releases page](../../releases) (có file `.bin` + checksum SHA256)
+- **Latest CI build**: [Actions tab](../../actions) — artifact `xiaozhi-vi-rlcd-4.2-*`
+
+## Flash lên board
+
+### Bước 1: Cài esptool
+
+```bash
+pip3 install --break-system-packages esptool
+```
+
+### Bước 2: Tìm USB port của board
+
+Trên macOS:
+
+```bash
+ls /dev/cu.usbmodem*
+```
+
+### Bước 3: Flash
+
+```bash
+# Erase trước (clear NVS để pick up locale mới)
+esptool.py --chip esp32s3 --port /dev/cu.usbmodem11301 --baud 460800 erase_flash
+
+# Flash firmware
+esptool.py --chip esp32s3 --port /dev/cu.usbmodem11301 --baud 115200 \
+    write_flash --no-compress 0x0 merged-binary.bin
+```
+
+### Bước 4: Verify
+
+Mở Serial Monitor để xem boot log:
+
+```bash
+screen /dev/cu.usbmodem11301 115200
+# Thoát: Ctrl+A, K, Y
+```
+
+Sau khi boot, UI sẽ hiển thị tiếng Việt: "Chờ", "Đang kết nối...", "Đang lắng nghe...", ...
+
+## Sync với upstream
+
+```bash
+git fetch upstream
+git checkout main
+git merge upstream/main
+git push origin main
+```
+
+## Build local (tùy chọn, không cần)
+
+GitHub Actions tự build, nhưng nếu muốn build local:
+
+```bash
+# Cài ESP-IDF v5.5.2
+git clone --recursive https://github.com/espressif/esp-idf.git ~/esp-idf
+cd ~/esp-idf && git checkout v5.5.2 && ./install.sh esp32s3
+source ~/esp-idf/export.sh
+
+# Build
+cd path/to/xiaozhi-esp32-vi
+python scripts/release.py waveshare/esp32-s3-rlcd-4.2 --name esp32-s3-rlcd-4.2-vi
+
+# Output: build/merged-binary.bin
+```
+
+## CI Workflows
+
+| Workflow | File | Trigger |
+|---|---|---|
+| Build VI Firmware | `.github/workflows/build-vi.yml` | push main/vi-build-rlcd, PR, manual dispatch |
+| Release VI Firmware | `.github/workflows/release-vi.yml` | tag push `v*-vi*` |
+| Upstream build (disabled) | `.github/workflows/build.yml` | workflow_dispatch only |
+
+## License
+
+Inherits MIT License from upstream [78/xiaozhi-esp32](https://github.com/78/xiaozhi-esp32).

--- a/main/boards/waveshare/esp32-s3-rlcd-4.2/config.json
+++ b/main/boards/waveshare/esp32-s3-rlcd-4.2/config.json
@@ -3,10 +3,12 @@
     "target": "esp32s3",
     "builds": [
         {
-            "name": "esp32-s3-rlcd-4.2",
+            "name": "esp32-s3-rlcd-4.2-vi",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
-                "CONFIG_USE_DEVICE_AEC=y"
+                "CONFIG_USE_DEVICE_AEC=y",
+                "CONFIG_LANGUAGE_VI_VN=y",
+                "CONFIG_LANGUAGE_ZH_CN=n"
             ]
         }
     ]


### PR DESCRIPTION
- Set CONFIG_LANGUAGE_VI_VN=y, disable ZH_CN in board config.json
- Rename build variant to esp32-s3-rlcd-4.2-vi
- Add README.vi.md documenting flash + sync workflow
- Add build-vi.yml: push/PR/dispatch triggers, builds only this board
- Add release-vi.yml: tag v*-vi* triggers, auto-creates GitHub Release
- Disable upstream build.yml auto-trigger to save CI minutes

vi-VN locale already exists upstream (52 strings translated, full TTS audio).