### PR TITLE
Fix board type selection for waveshare esp32-s3-epaper-1.54

### DIFF
--- a/main/boards/waveshare/esp32-s3-epaper-1.54/config.json
+++ b/main/boards/waveshare/esp32-s3-epaper-1.54/config.json
@@ -5,6 +5,7 @@
         {
             "name": "esp32-s3-epaper-1.54-v2",
             "sdkconfig_append": [
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_S3_ePaper_1_54_v2=y",
                 "CONFIG_ESPTOOLPY_FLASHSIZE_8MB=y",
                 "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/8m.csv\"",
                 "CONFIG_USE_MULTILINE_CHAT_MESSAGE=y"
@@ -13,6 +14,7 @@
         {
             "name": "esp32-s3-epaper-1.54-v1",
             "sdkconfig_append": [
+                "CONFIG_BOARD_TYPE_WAVESHARE_ESP32_S3_ePaper_1_54_v1=y",
                 "CONFIG_SPIRAM_MODE_QUAD=y",
                 "CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y",
                 "CONFIG_PARTITION_TABLE_CUSTOM_FILENAME=\"partitions/v2/4m.csv\"",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -162,7 +162,7 @@ def _find_board_config_candidates(board_type: str) -> list[str]:
 
 def _extract_board_config_from_sdkconfig_append(sdkconfig_append: list[str]) -> Optional[str]:
     """Extract explicit CONFIG_BOARD_TYPE_xxx=y from sdkconfig_append, if present."""
-    pattern = re.compile(r"^(CONFIG_BOARD_TYPE_[A-Z0-9_]+)=y$")
+    pattern = re.compile(r"^(CONFIG_BOARD_TYPE_[A-Za-z0-9_]+)=y$")
     matches = []
     for item in sdkconfig_append:
         m = pattern.match(item.strip())


### PR DESCRIPTION
Right now when we follow the tips in:
https://github.com/78/xiaozhi-esp32/tree/main/main/boards/waveshare/esp32-s3-epaper-1.54 and run the following command:

python ./scripts/release.py --name esp32-s3-epaper-1.54-v2 waveshare/esp32-s3-epaper-1.54

It will actually build the firmware for v1. This commit fixes it.