### PR TITLE
chore: temporarily disable touch sensor for ESP-VoCat on IDF v6

### DIFF
--- a/main/boards/esp-vocat/esp_vocat.cc
+++ b/main/boards/esp-vocat/esp_vocat.cc
@@ -1,46 +1,49 @@
-#include "wifi_board.h"
-#include "codecs/box_audio_codec.h"
-#include "display/lcd_display.h"
-#include "display/emote_display.h"
 #include "application.h"
-#include "button.h"
-#include "config.h"
 #include "backlight.h"
+#include "button.h"
+#include "codecs/box_audio_codec.h"
+#include "config.h"
+#include "display/emote_display.h"
+#include "display/lcd_display.h"
 #include "esp_video.h"
+#include "wifi_board.h"
 
 #include <esp_log.h>
 #include <esp_timer.h>
-#include "esp_idf_version.h"
 #include <cinttypes>
+#include "esp_idf_version.h"
+
+#define ESP_VOCAT_ENABLE_CAP_TOUCH_SENSOR (ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(6, 0, 0))
 
 #include <driver/i2c_master.h>
-#include <cstdlib>
-#include "i2c_device.h"
-#include "i2c_bus.h"
-#include "bmi270_api.h"
 #include <esp_lcd_panel_io.h>
 #include <esp_lcd_panel_ops.h>
 #include <esp_lcd_st77916.h>
+#include <cstdlib>
+#include "bmi270_api.h"
 #include "esp_lcd_touch_cst816s.h"
+#include "i2c_bus.h"
+#include "i2c_device.h"
 #include "touch.h"
 
+#if ESP_VOCAT_ENABLE_CAP_TOUCH_SENSOR
 extern "C" {
 #include "touch_button_sensor.h"
 #include "touch_slider_sensor.h"
 }
+#endif
 
-#include "driver/temperature_sensor.h"
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 #include <freertos/task.h>
+#include "driver/temperature_sensor.h"
 
 #define TAG "ESP-VoCat"
 
 namespace Bmi270Motion {
 static bmi270_handle_t bmi_handle_ = nullptr;
 
-esp_err_t Initialize(i2c_bus_handle_t i2c_bus)
-{
+esp_err_t Initialize(i2c_bus_handle_t i2c_bus) {
     if (bmi_handle_) {
         return ESP_OK;
     }
@@ -66,203 +69,207 @@ esp_err_t Initialize(i2c_bus_handle_t i2c_bus)
     return ESP_OK;
 }
 
-bool ReadAccelRaw(struct bmi2_sens_data& accel)
-{
+bool ReadAccelRaw(struct bmi2_sens_data& accel) {
     if (!bmi_handle_) {
         return false;
     }
     int8_t rslt = bmi2_get_sensor_data(&accel, bmi_handle_);
     return rslt == BMI2_OK;
 }
-} // namespace Bmi270Motion
-
+}  // namespace Bmi270Motion
 
 temperature_sensor_handle_t temp_sensor = NULL;
 static const st77916_lcd_init_cmd_t vendor_specific_init_yysj[] = {
-    {0xF0, (uint8_t []){0x28}, 1, 0},
-    {0xF2, (uint8_t []){0x28}, 1, 0},
-    {0x73, (uint8_t []){0xF0}, 1, 0},
-    {0x7C, (uint8_t []){0xD1}, 1, 0},
-    {0x83, (uint8_t []){0xE0}, 1, 0},
-    {0x84, (uint8_t []){0x61}, 1, 0},
-    {0xF2, (uint8_t []){0x82}, 1, 0},
-    {0xF0, (uint8_t []){0x00}, 1, 0},
-    {0xF0, (uint8_t []){0x01}, 1, 0},
-    {0xF1, (uint8_t []){0x01}, 1, 0},
-    {0xB0, (uint8_t []){0x56}, 1, 0},
-    {0xB1, (uint8_t []){0x4D}, 1, 0},
-    {0xB2, (uint8_t []){0x24}, 1, 0},
-    {0xB4, (uint8_t []){0x87}, 1, 0},
-    {0xB5, (uint8_t []){0x44}, 1, 0},
-    {0xB6, (uint8_t []){0x8B}, 1, 0},
-    {0xB7, (uint8_t []){0x40}, 1, 0},
-    {0xB8, (uint8_t []){0x86}, 1, 0},
-    {0xBA, (uint8_t []){0x00}, 1, 0},
-    {0xBB, (uint8_t []){0x08}, 1, 0},
-    {0xBC, (uint8_t []){0x08}, 1, 0},
-    {0xBD, (uint8_t []){0x00}, 1, 0},
-    {0xC0, (uint8_t []){0x80}, 1, 0},
-    {0xC1, (uint8_t []){0x10}, 1, 0},
-    {0xC2, (uint8_t []){0x37}, 1, 0},
-    {0xC3, (uint8_t []){0x80}, 1, 0},
-    {0xC4, (uint8_t []){0x10}, 1, 0},
-    {0xC5, (uint8_t []){0x37}, 1, 0},
-    {0xC6, (uint8_t []){0xA9}, 1, 0},
-    {0xC7, (uint8_t []){0x41}, 1, 0},
-    {0xC8, (uint8_t []){0x01}, 1, 0},
-    {0xC9, (uint8_t []){0xA9}, 1, 0},
-    {0xCA, (uint8_t []){0x41}, 1, 0},
-    {0xCB, (uint8_t []){0x01}, 1, 0},
-    {0xD0, (uint8_t []){0x91}, 1, 0},
-    {0xD1, (uint8_t []){0x68}, 1, 0},
-    {0xD2, (uint8_t []){0x68}, 1, 0},
-    {0xF5, (uint8_t []){0x00, 0xA5}, 2, 0},
-    {0xDD, (uint8_t []){0x4F}, 1, 0},
-    {0xDE, (uint8_t []){0x4F}, 1, 0},
-    {0xF1, (uint8_t []){0x10}, 1, 0},
-    {0xF0, (uint8_t []){0x00}, 1, 0},
-    {0xF0, (uint8_t []){0x02}, 1, 0},
-    {0xE0, (uint8_t []){0xF0, 0x0A, 0x10, 0x09, 0x09, 0x36, 0x35, 0x33, 0x4A, 0x29, 0x15, 0x15, 0x2E, 0x34}, 14, 0},
-    {0xE1, (uint8_t []){0xF0, 0x0A, 0x0F, 0x08, 0x08, 0x05, 0x34, 0x33, 0x4A, 0x39, 0x15, 0x15, 0x2D, 0x33}, 14, 0},
-    {0xF0, (uint8_t []){0x10}, 1, 0},
-    {0xF3, (uint8_t []){0x10}, 1, 0},
-    {0xE0, (uint8_t []){0x07}, 1, 0},
-    {0xE1, (uint8_t []){0x00}, 1, 0},
-    {0xE2, (uint8_t []){0x00}, 1, 0},
-    {0xE3, (uint8_t []){0x00}, 1, 0},
-    {0xE4, (uint8_t []){0xE0}, 1, 0},
-    {0xE5, (uint8_t []){0x06}, 1, 0},
-    {0xE6, (uint8_t []){0x21}, 1, 0},
-    {0xE7, (uint8_t []){0x01}, 1, 0},
-    {0xE8, (uint8_t []){0x05}, 1, 0},
-    {0xE9, (uint8_t []){0x02}, 1, 0},
-    {0xEA, (uint8_t []){0xDA}, 1, 0},
-    {0xEB, (uint8_t []){0x00}, 1, 0},
-    {0xEC, (uint8_t []){0x00}, 1, 0},
-    {0xED, (uint8_t []){0x0F}, 1, 0},
-    {0xEE, (uint8_t []){0x00}, 1, 0},
-    {0xEF, (uint8_t []){0x00}, 1, 0},
-    {0xF8, (uint8_t []){0x00}, 1, 0},
-    {0xF9, (uint8_t []){0x00}, 1, 0},
-    {0xFA, (uint8_t []){0x00}, 1, 0},
-    {0xFB, (uint8_t []){0x00}, 1, 0},
-    {0xFC, (uint8_t []){0x00}, 1, 0},
-    {0xFD, (uint8_t []){0x00}, 1, 0},
-    {0xFE, (uint8_t []){0x00}, 1, 0},
-    {0xFF, (uint8_t []){0x00}, 1, 0},
-    {0x60, (uint8_t []){0x40}, 1, 0},
-    {0x61, (uint8_t []){0x04}, 1, 0},
-    {0x62, (uint8_t []){0x00}, 1, 0},
-    {0x63, (uint8_t []){0x42}, 1, 0},
-    {0x64, (uint8_t []){0xD9}, 1, 0},
-    {0x65, (uint8_t []){0x00}, 1, 0},
-    {0x66, (uint8_t []){0x00}, 1, 0},
-    {0x67, (uint8_t []){0x00}, 1, 0},
-    {0x68, (uint8_t []){0x00}, 1, 0},
-    {0x69, (uint8_t []){0x00}, 1, 0},
-    {0x6A, (uint8_t []){0x00}, 1, 0},
-    {0x6B, (uint8_t []){0x00}, 1, 0},
-    {0x70, (uint8_t []){0x40}, 1, 0},
-    {0x71, (uint8_t []){0x03}, 1, 0},
-    {0x72, (uint8_t []){0x00}, 1, 0},
-    {0x73, (uint8_t []){0x42}, 1, 0},
-    {0x74, (uint8_t []){0xD8}, 1, 0},
-    {0x75, (uint8_t []){0x00}, 1, 0},
-    {0x76, (uint8_t []){0x00}, 1, 0},
-    {0x77, (uint8_t []){0x00}, 1, 0},
-    {0x78, (uint8_t []){0x00}, 1, 0},
-    {0x79, (uint8_t []){0x00}, 1, 0},
-    {0x7A, (uint8_t []){0x00}, 1, 0},
-    {0x7B, (uint8_t []){0x00}, 1, 0},
-    {0x80, (uint8_t []){0x48}, 1, 0},
-    {0x81, (uint8_t []){0x00}, 1, 0},
-    {0x82, (uint8_t []){0x06}, 1, 0},
-    {0x83, (uint8_t []){0x02}, 1, 0},
-    {0x84, (uint8_t []){0xD6}, 1, 0},
-    {0x85, (uint8_t []){0x04}, 1, 0},
-    {0x86, (uint8_t []){0x00}, 1, 0},
-    {0x87, (uint8_t []){0x00}, 1, 0},
-    {0x88, (uint8_t []){0x48}, 1, 0},
-    {0x89, (uint8_t []){0x00}, 1, 0},
-    {0x8A, (uint8_t []){0x08}, 1, 0},
-    {0x8B, (uint8_t []){0x02}, 1, 0},
-    {0x8C, (uint8_t []){0xD8}, 1, 0},
-    {0x8D, (uint8_t []){0x04}, 1, 0},
-    {0x8E, (uint8_t []){0x00}, 1, 0},
-    {0x8F, (uint8_t []){0x00}, 1, 0},
-    {0x90, (uint8_t []){0x48}, 1, 0},
-    {0x91, (uint8_t []){0x00}, 1, 0},
-    {0x92, (uint8_t []){0x0A}, 1, 0},
-    {0x93, (uint8_t []){0x02}, 1, 0},
-    {0x94, (uint8_t []){0xDA}, 1, 0},
-    {0x95, (uint8_t []){0x04}, 1, 0},
-    {0x96, (uint8_t []){0x00}, 1, 0},
-    {0x97, (uint8_t []){0x00}, 1, 0},
-    {0x98, (uint8_t []){0x48}, 1, 0},
-    {0x99, (uint8_t []){0x00}, 1, 0},
-    {0x9A, (uint8_t []){0x0C}, 1, 0},
-    {0x9B, (uint8_t []){0x02}, 1, 0},
-    {0x9C, (uint8_t []){0xDC}, 1, 0},
-    {0x9D, (uint8_t []){0x04}, 1, 0},
-    {0x9E, (uint8_t []){0x00}, 1, 0},
-    {0x9F, (uint8_t []){0x00}, 1, 0},
-    {0xA0, (uint8_t []){0x48}, 1, 0},
-    {0xA1, (uint8_t []){0x00}, 1, 0},
-    {0xA2, (uint8_t []){0x05}, 1, 0},
-    {0xA3, (uint8_t []){0x02}, 1, 0},
-    {0xA4, (uint8_t []){0xD5}, 1, 0},
-    {0xA5, (uint8_t []){0x04}, 1, 0},
-    {0xA6, (uint8_t []){0x00}, 1, 0},
-    {0xA7, (uint8_t []){0x00}, 1, 0},
-    {0xA8, (uint8_t []){0x48}, 1, 0},
-    {0xA9, (uint8_t []){0x00}, 1, 0},
-    {0xAA, (uint8_t []){0x07}, 1, 0},
-    {0xAB, (uint8_t []){0x02}, 1, 0},
-    {0xAC, (uint8_t []){0xD7}, 1, 0},
-    {0xAD, (uint8_t []){0x04}, 1, 0},
-    {0xAE, (uint8_t []){0x00}, 1, 0},
-    {0xAF, (uint8_t []){0x00}, 1, 0},
-    {0xB0, (uint8_t []){0x48}, 1, 0},
-    {0xB1, (uint8_t []){0x00}, 1, 0},
-    {0xB2, (uint8_t []){0x09}, 1, 0},
-    {0xB3, (uint8_t []){0x02}, 1, 0},
-    {0xB4, (uint8_t []){0xD9}, 1, 0},
-    {0xB5, (uint8_t []){0x04}, 1, 0},
-    {0xB6, (uint8_t []){0x00}, 1, 0},
-    {0xB7, (uint8_t []){0x00}, 1, 0},
-    {0xB8, (uint8_t []){0x48}, 1, 0},
-    {0xB9, (uint8_t []){0x00}, 1, 0},
-    {0xBA, (uint8_t []){0x0B}, 1, 0},
-    {0xBB, (uint8_t []){0x02}, 1, 0},
-    {0xBC, (uint8_t []){0xDB}, 1, 0},
-    {0xBD, (uint8_t []){0x04}, 1, 0},
-    {0xBE, (uint8_t []){0x00}, 1, 0},
-    {0xBF, (uint8_t []){0x00}, 1, 0},
-    {0xC0, (uint8_t []){0x10}, 1, 0},
-    {0xC1, (uint8_t []){0x47}, 1, 0},
-    {0xC2, (uint8_t []){0x56}, 1, 0},
-    {0xC3, (uint8_t []){0x65}, 1, 0},
-    {0xC4, (uint8_t []){0x74}, 1, 0},
-    {0xC5, (uint8_t []){0x88}, 1, 0},
-    {0xC6, (uint8_t []){0x99}, 1, 0},
-    {0xC7, (uint8_t []){0x01}, 1, 0},
-    {0xC8, (uint8_t []){0xBB}, 1, 0},
-    {0xC9, (uint8_t []){0xAA}, 1, 0},
-    {0xD0, (uint8_t []){0x10}, 1, 0},
-    {0xD1, (uint8_t []){0x47}, 1, 0},
-    {0xD2, (uint8_t []){0x56}, 1, 0},
-    {0xD3, (uint8_t []){0x65}, 1, 0},
-    {0xD4, (uint8_t []){0x74}, 1, 0},
-    {0xD5, (uint8_t []){0x88}, 1, 0},
-    {0xD6, (uint8_t []){0x99}, 1, 0},
-    {0xD7, (uint8_t []){0x01}, 1, 0},
-    {0xD8, (uint8_t []){0xBB}, 1, 0},
-    {0xD9, (uint8_t []){0xAA}, 1, 0},
-    {0xF3, (uint8_t []){0x01}, 1, 0},
-    {0xF0, (uint8_t []){0x00}, 1, 0},
-    {0x21, (uint8_t []){}, 0, 0},
-    {0x11, (uint8_t []){}, 0, 0},
-    {0x00, (uint8_t []){}, 0, 120},
+    {0xF0, (uint8_t[]){0x28}, 1, 0},
+    {0xF2, (uint8_t[]){0x28}, 1, 0},
+    {0x73, (uint8_t[]){0xF0}, 1, 0},
+    {0x7C, (uint8_t[]){0xD1}, 1, 0},
+    {0x83, (uint8_t[]){0xE0}, 1, 0},
+    {0x84, (uint8_t[]){0x61}, 1, 0},
+    {0xF2, (uint8_t[]){0x82}, 1, 0},
+    {0xF0, (uint8_t[]){0x00}, 1, 0},
+    {0xF0, (uint8_t[]){0x01}, 1, 0},
+    {0xF1, (uint8_t[]){0x01}, 1, 0},
+    {0xB0, (uint8_t[]){0x56}, 1, 0},
+    {0xB1, (uint8_t[]){0x4D}, 1, 0},
+    {0xB2, (uint8_t[]){0x24}, 1, 0},
+    {0xB4, (uint8_t[]){0x87}, 1, 0},
+    {0xB5, (uint8_t[]){0x44}, 1, 0},
+    {0xB6, (uint8_t[]){0x8B}, 1, 0},
+    {0xB7, (uint8_t[]){0x40}, 1, 0},
+    {0xB8, (uint8_t[]){0x86}, 1, 0},
+    {0xBA, (uint8_t[]){0x00}, 1, 0},
+    {0xBB, (uint8_t[]){0x08}, 1, 0},
+    {0xBC, (uint8_t[]){0x08}, 1, 0},
+    {0xBD, (uint8_t[]){0x00}, 1, 0},
+    {0xC0, (uint8_t[]){0x80}, 1, 0},
+    {0xC1, (uint8_t[]){0x10}, 1, 0},
+    {0xC2, (uint8_t[]){0x37}, 1, 0},
+    {0xC3, (uint8_t[]){0x80}, 1, 0},
+    {0xC4, (uint8_t[]){0x10}, 1, 0},
+    {0xC5, (uint8_t[]){0x37}, 1, 0},
+    {0xC6, (uint8_t[]){0xA9}, 1, 0},
+    {0xC7, (uint8_t[]){0x41}, 1, 0},
+    {0xC8, (uint8_t[]){0x01}, 1, 0},
+    {0xC9, (uint8_t[]){0xA9}, 1, 0},
+    {0xCA, (uint8_t[]){0x41}, 1, 0},
+    {0xCB, (uint8_t[]){0x01}, 1, 0},
+    {0xD0, (uint8_t[]){0x91}, 1, 0},
+    {0xD1, (uint8_t[]){0x68}, 1, 0},
+    {0xD2, (uint8_t[]){0x68}, 1, 0},
+    {0xF5, (uint8_t[]){0x00, 0xA5}, 2, 0},
+    {0xDD, (uint8_t[]){0x4F}, 1, 0},
+    {0xDE, (uint8_t[]){0x4F}, 1, 0},
+    {0xF1, (uint8_t[]){0x10}, 1, 0},
+    {0xF0, (uint8_t[]){0x00}, 1, 0},
+    {0xF0, (uint8_t[]){0x02}, 1, 0},
+    {0xE0,
+     (uint8_t[]){0xF0, 0x0A, 0x10, 0x09, 0x09, 0x36, 0x35, 0x33, 0x4A, 0x29, 0x15, 0x15, 0x2E,
+                 0x34},
+     14, 0},
+    {0xE1,
+     (uint8_t[]){0xF0, 0x0A, 0x0F, 0x08, 0x08, 0x05, 0x34, 0x33, 0x4A, 0x39, 0x15, 0x15, 0x2D,
+                 0x33},
+     14, 0},
+    {0xF0, (uint8_t[]){0x10}, 1, 0},
+    {0xF3, (uint8_t[]){0x10}, 1, 0},
+    {0xE0, (uint8_t[]){0x07}, 1, 0},
+    {0xE1, (uint8_t[]){0x00}, 1, 0},
+    {0xE2, (uint8_t[]){0x00}, 1, 0},
+    {0xE3, (uint8_t[]){0x00}, 1, 0},
+    {0xE4, (uint8_t[]){0xE0}, 1, 0},
+    {0xE5, (uint8_t[]){0x06}, 1, 0},
+    {0xE6, (uint8_t[]){0x21}, 1, 0},
+    {0xE7, (uint8_t[]){0x01}, 1, 0},
+    {0xE8, (uint8_t[]){0x05}, 1, 0},
+    {0xE9, (uint8_t[]){0x02}, 1, 0},
+    {0xEA, (uint8_t[]){0xDA}, 1, 0},
+    {0xEB, (uint8_t[]){0x00}, 1, 0},
+    {0xEC, (uint8_t[]){0x00}, 1, 0},
+    {0xED, (uint8_t[]){0x0F}, 1, 0},
+    {0xEE, (uint8_t[]){0x00}, 1, 0},
+    {0xEF, (uint8_t[]){0x00}, 1, 0},
+    {0xF8, (uint8_t[]){0x00}, 1, 0},
+    {0xF9, (uint8_t[]){0x00}, 1, 0},
+    {0xFA, (uint8_t[]){0x00}, 1, 0},
+    {0xFB, (uint8_t[]){0x00}, 1, 0},
+    {0xFC, (uint8_t[]){0x00}, 1, 0},
+    {0xFD, (uint8_t[]){0x00}, 1, 0},
+    {0xFE, (uint8_t[]){0x00}, 1, 0},
+    {0xFF, (uint8_t[]){0x00}, 1, 0},
+    {0x60, (uint8_t[]){0x40}, 1, 0},
+    {0x61, (uint8_t[]){0x04}, 1, 0},
+    {0x62, (uint8_t[]){0x00}, 1, 0},
+    {0x63, (uint8_t[]){0x42}, 1, 0},
+    {0x64, (uint8_t[]){0xD9}, 1, 0},
+    {0x65, (uint8_t[]){0x00}, 1, 0},
+    {0x66, (uint8_t[]){0x00}, 1, 0},
+    {0x67, (uint8_t[]){0x00}, 1, 0},
+    {0x68, (uint8_t[]){0x00}, 1, 0},
+    {0x69, (uint8_t[]){0x00}, 1, 0},
+    {0x6A, (uint8_t[]){0x00}, 1, 0},
+    {0x6B, (uint8_t[]){0x00}, 1, 0},
+    {0x70, (uint8_t[]){0x40}, 1, 0},
+    {0x71, (uint8_t[]){0x03}, 1, 0},
+    {0x72, (uint8_t[]){0x00}, 1, 0},
+    {0x73, (uint8_t[]){0x42}, 1, 0},
+    {0x74, (uint8_t[]){0xD8}, 1, 0},
+    {0x75, (uint8_t[]){0x00}, 1, 0},
+    {0x76, (uint8_t[]){0x00}, 1, 0},
+    {0x77, (uint8_t[]){0x00}, 1, 0},
+    {0x78, (uint8_t[]){0x00}, 1, 0},
+    {0x79, (uint8_t[]){0x00}, 1, 0},
+    {0x7A, (uint8_t[]){0x00}, 1, 0},
+    {0x7B, (uint8_t[]){0x00}, 1, 0},
+    {0x80, (uint8_t[]){0x48}, 1, 0},
+    {0x81, (uint8_t[]){0x00}, 1, 0},
+    {0x82, (uint8_t[]){0x06}, 1, 0},
+    {0x83, (uint8_t[]){0x02}, 1, 0},
+    {0x84, (uint8_t[]){0xD6}, 1, 0},
+    {0x85, (uint8_t[]){0x04}, 1, 0},
+    {0x86, (uint8_t[]){0x00}, 1, 0},
+    {0x87, (uint8_t[]){0x00}, 1, 0},
+    {0x88, (uint8_t[]){0x48}, 1, 0},
+    {0x89, (uint8_t[]){0x00}, 1, 0},
+    {0x8A, (uint8_t[]){0x08}, 1, 0},
+    {0x8B, (uint8_t[]){0x02}, 1, 0},
+    {0x8C, (uint8_t[]){0xD8}, 1, 0},
+    {0x8D, (uint8_t[]){0x04}, 1, 0},
+    {0x8E, (uint8_t[]){0x00}, 1, 0},
+    {0x8F, (uint8_t[]){0x00}, 1, 0},
+    {0x90, (uint8_t[]){0x48}, 1, 0},
+    {0x91, (uint8_t[]){0x00}, 1, 0},
+    {0x92, (uint8_t[]){0x0A}, 1, 0},
+    {0x93, (uint8_t[]){0x02}, 1, 0},
+    {0x94, (uint8_t[]){0xDA}, 1, 0},
+    {0x95, (uint8_t[]){0x04}, 1, 0},
+    {0x96, (uint8_t[]){0x00}, 1, 0},
+    {0x97, (uint8_t[]){0x00}, 1, 0},
+    {0x98, (uint8_t[]){0x48}, 1, 0},
+    {0x99, (uint8_t[]){0x00}, 1, 0},
+    {0x9A, (uint8_t[]){0x0C}, 1, 0},
+    {0x9B, (uint8_t[]){0x02}, 1, 0},
+    {0x9C, (uint8_t[]){0xDC}, 1, 0},
+    {0x9D, (uint8_t[]){0x04}, 1, 0},
+    {0x9E, (uint8_t[]){0x00}, 1, 0},
+    {0x9F, (uint8_t[]){0x00}, 1, 0},
+    {0xA0, (uint8_t[]){0x48}, 1, 0},
+    {0xA1, (uint8_t[]){0x00}, 1, 0},
+    {0xA2, (uint8_t[]){0x05}, 1, 0},
+    {0xA3, (uint8_t[]){0x02}, 1, 0},
+    {0xA4, (uint8_t[]){0xD5}, 1, 0},
+    {0xA5, (uint8_t[]){0x04}, 1, 0},
+    {0xA6, (uint8_t[]){0x00}, 1, 0},
+    {0xA7, (uint8_t[]){0x00}, 1, 0},
+    {0xA8, (uint8_t[]){0x48}, 1, 0},
+    {0xA9, (uint8_t[]){0x00}, 1, 0},
+    {0xAA, (uint8_t[]){0x07}, 1, 0},
+    {0xAB, (uint8_t[]){0x02}, 1, 0},
+    {0xAC, (uint8_t[]){0xD7}, 1, 0},
+    {0xAD, (uint8_t[]){0x04}, 1, 0},
+    {0xAE, (uint8_t[]){0x00}, 1, 0},
+    {0xAF, (uint8_t[]){0x00}, 1, 0},
+    {0xB0, (uint8_t[]){0x48}, 1, 0},
+    {0xB1, (uint8_t[]){0x00}, 1, 0},
+    {0xB2, (uint8_t[]){0x09}, 1, 0},
+    {0xB3, (uint8_t[]){0x02}, 1, 0},
+    {0xB4, (uint8_t[]){0xD9}, 1, 0},
+    {0xB5, (uint8_t[]){0x04}, 1, 0},
+    {0xB6, (uint8_t[]){0x00}, 1, 0},
+    {0xB7, (uint8_t[]){0x00}, 1, 0},
+    {0xB8, (uint8_t[]){0x48}, 1, 0},
+    {0xB9, (uint8_t[]){0x00}, 1, 0},
+    {0xBA, (uint8_t[]){0x0B}, 1, 0},
+    {0xBB, (uint8_t[]){0x02}, 1, 0},
+    {0xBC, (uint8_t[]){0xDB}, 1, 0},
+    {0xBD, (uint8_t[]){0x04}, 1, 0},
+    {0xBE, (uint8_t[]){0x00}, 1, 0},
+    {0xBF, (uint8_t[]){0x00}, 1, 0},
+    {0xC0, (uint8_t[]){0x10}, 1, 0},
+    {0xC1, (uint8_t[]){0x47}, 1, 0},
+    {0xC2, (uint8_t[]){0x56}, 1, 0},
+    {0xC3, (uint8_t[]){0x65}, 1, 0},
+    {0xC4, (uint8_t[]){0x74}, 1, 0},
+    {0xC5, (uint8_t[]){0x88}, 1, 0},
+    {0xC6, (uint8_t[]){0x99}, 1, 0},
+    {0xC7, (uint8_t[]){0x01}, 1, 0},
+    {0xC8, (uint8_t[]){0xBB}, 1, 0},
+    {0xC9, (uint8_t[]){0xAA}, 1, 0},
+    {0xD0, (uint8_t[]){0x10}, 1, 0},
+    {0xD1, (uint8_t[]){0x47}, 1, 0},
+    {0xD2, (uint8_t[]){0x56}, 1, 0},
+    {0xD3, (uint8_t[]){0x65}, 1, 0},
+    {0xD4, (uint8_t[]){0x74}, 1, 0},
+    {0xD5, (uint8_t[]){0x88}, 1, 0},
+    {0xD6, (uint8_t[]){0x99}, 1, 0},
+    {0xD7, (uint8_t[]){0x01}, 1, 0},
+    {0xD8, (uint8_t[]){0xBB}, 1, 0},
+    {0xD9, (uint8_t[]){0xAA}, 1, 0},
+    {0xF3, (uint8_t[]){0x01}, 1, 0},
+    {0xF0, (uint8_t[]){0x00}, 1, 0},
+    {0x21, (uint8_t[]){}, 0, 0},
+    {0x11, (uint8_t[]){}, 0, 0},
+    {0x00, (uint8_t[]){}, 0, 120},
 };
 float tsens_value;
 gpio_num_t AUDIO_I2S_GPIO_DIN = AUDIO_I2S_GPIO_DIN_1;
@@ -284,24 +291,19 @@ public:
     static constexpr int kChargingCurrentMa = 30;
     static constexpr uint16_t kBatteryStatusDsg = BIT0;
 
-    Charge(i2c_master_bus_handle_t i2c_bus, uint8_t addr) : I2cDevice(i2c_bus, addr)
-    {
+    Charge(i2c_master_bus_handle_t i2c_bus, uint8_t addr) : I2cDevice(i2c_bus, addr) {
         read_buffer_ = new uint8_t[8];
     }
-    ~Charge()
-    {
-        delete[] read_buffer_;
-    }
+    ~Charge() { delete[] read_buffer_; }
 
-    int16_t ReadWord(uint8_t reg)
-    {
+    int16_t ReadWord(uint8_t reg) {
         uint8_t data[2] = {0};
         ReadRegs(reg, data, 2);
-        return static_cast<int16_t>(static_cast<uint16_t>(data[0]) | (static_cast<uint16_t>(data[1]) << 8));
+        return static_cast<int16_t>(static_cast<uint16_t>(data[0]) |
+                                    (static_cast<uint16_t>(data[1]) << 8));
     }
 
-    int GetBatteryLevel()
-    {
+    int GetBatteryLevel() {
         int level = ReadWord(kRegStateOfCharge);
         if (level < 0) {
             return 0;
@@ -312,8 +314,7 @@ public:
         return level;
     }
 
-    bool IsCharging()
-    {
+    bool IsCharging() {
         const uint16_t status = static_cast<uint16_t>(ReadWord(kRegBatteryStatus));
         if ((status & kBatteryStatusDsg) == 0) {
             return true;
@@ -325,13 +326,11 @@ public:
         return avg_current_ma > kChargingCurrentMa || current_ma > kChargingCurrentMa;
     }
 
-    bool IsDischarging()
-    {
+    bool IsDischarging() {
         return (static_cast<uint16_t>(ReadWord(kRegBatteryStatus)) & kBatteryStatusDsg) != 0;
     }
 
-    void Update()
-    {
+    void Update() {
         const int16_t voltage = ReadWord(kRegVoltage);
         const int16_t current = ReadWord(kRegCurrent);
         ESP_ERROR_CHECK(temperature_sensor_get_celsius(temp_sensor, &tsens_value));
@@ -351,15 +350,9 @@ public:
         int y = -1;
     };
 
-    enum TouchEvent {
-        TOUCH_NONE,
-        TOUCH_PRESS,
-        TOUCH_RELEASE,
-        TOUCH_HOLD
-    };
+    enum TouchEvent { TOUCH_NONE, TOUCH_PRESS, TOUCH_RELEASE, TOUCH_HOLD };
 
-    Cst816s(i2c_master_bus_handle_t i2c_bus, uint8_t addr) : I2cDevice(i2c_bus, addr)
-    {
+    Cst816s(i2c_master_bus_handle_t i2c_bus, uint8_t addr) : I2cDevice(i2c_bus, addr) {
         read_buffer_ = new uint8_t[6];
         was_touched_ = false;
         press_count_ = 0;
@@ -371,8 +364,7 @@ public:
         }
     }
 
-    ~Cst816s()
-    {
+    ~Cst816s() {
         delete[] read_buffer_;
 
         // Delete semaphore if it exists
@@ -382,21 +374,16 @@ public:
         }
     }
 
-    void UpdateTouchPoint()
-    {
+    void UpdateTouchPoint() {
         ReadRegs(0x02, read_buffer_, 6);
         tp_.num = read_buffer_[0] & 0x0F;
         tp_.x = ((read_buffer_[1] & 0x0F) << 8) | read_buffer_[2];
         tp_.y = ((read_buffer_[3] & 0x0F) << 8) | read_buffer_[4];
     }
 
-    const TouchPoint_t &GetTouchPoint()
-    {
-        return tp_;
-    }
+    const TouchPoint_t& GetTouchPoint() { return tp_; }
 
-    TouchEvent CheckTouchEvent()
-    {
+    TouchEvent CheckTouchEvent() {
         bool is_touched = (tp_.num > 0);
         TouchEvent event = TOUCH_NONE;
 
@@ -420,32 +407,21 @@ public:
         return event;
     }
 
-    int GetPressCount() const
-    {
-        return press_count_;
-    }
+    int GetPressCount() const { return press_count_; }
 
-    void ResetPressCount()
-    {
-        press_count_ = 0;
-    }
+    void ResetPressCount() { press_count_ = 0; }
 
     // Semaphore management methods
-    SemaphoreHandle_t GetTouchSemaphore()
-    {
-        return touch_isr_mux_;
-    }
+    SemaphoreHandle_t GetTouchSemaphore() { return touch_isr_mux_; }
 
-    bool WaitForTouchEvent(TickType_t timeout = portMAX_DELAY)
-    {
+    bool WaitForTouchEvent(TickType_t timeout = portMAX_DELAY) {
         if (touch_isr_mux_ != NULL) {
             return xSemaphoreTake(touch_isr_mux_, timeout) == pdTRUE;
         }
         return false;
     }
 
-    void NotifyTouchEvent()
-    {
+    void NotifyTouchEvent() {
         if (touch_isr_mux_ != NULL) {
             BaseType_t xHigherPriorityTaskWoken = pdFALSE;
             xSemaphoreGiveFromISR(touch_isr_mux_, &xHigherPriorityTaskWoken);
@@ -475,43 +451,45 @@ private:
     Display* display_ = nullptr;
     PwmBacklight* backlight_ = nullptr;
     esp_timer_handle_t touchpad_timer_;
-    esp_lcd_touch_handle_t tp;   // LCD touch handle
+    esp_lcd_touch_handle_t tp;  // LCD touch handle
     EspVideo* camera_ = nullptr;
     TaskHandle_t charge_task_handle_ = nullptr;
     TaskHandle_t touch_task_handle_ = nullptr;
     TaskHandle_t imu_task_handle_ = nullptr;
+#if ESP_VOCAT_ENABLE_CAP_TOUCH_SENSOR
     TaskHandle_t touch_slider_task_handle_ = nullptr;
+#endif
     esp_timer_handle_t emotion_reset_timer_ = nullptr;
     bool bmi270_ready_ = false;
     bool was_charging_ = false;
     uint8_t low_battery_alert_mask_ = 0;
     int low_battery_plays_left_ = 0;
     int64_t next_low_battery_play_ms_ = 0;
+#if ESP_VOCAT_ENABLE_CAP_TOUCH_SENSOR
     touch_slider_handle_t touch_slider_handle_ = nullptr;
     touch_button_handle_t touch_button_handle_ = nullptr;
+#endif
 
-    static void emotion_reset_timer_callback(void* arg)
-    {
+    static void emotion_reset_timer_callback(void* arg) {
         auto* self = static_cast<EspVocat*>(arg);
         if (self && self->display_ != nullptr) {
             self->display_->SetEmotion("neutral");
         }
     }
 
-    void ShowTemporaryEmotion(const char* emotion, uint32_t duration_ms)
-    {
+    void ShowTemporaryEmotion(const char* emotion, uint32_t duration_ms) {
         if (display_ == nullptr || emotion == nullptr) {
             return;
         }
         display_->SetEmotion(emotion);
         if (emotion_reset_timer_ != nullptr) {
             esp_timer_stop(emotion_reset_timer_);
-            esp_timer_start_once(emotion_reset_timer_, static_cast<uint64_t>(duration_ms) * 1000ULL);
+            esp_timer_start_once(emotion_reset_timer_,
+                                 static_cast<uint64_t>(duration_ms) * 1000ULL);
         }
     }
 
-    void ShowHappyTouchFeedback()
-    {
+    void ShowHappyTouchFeedback() {
         static int64_t s_last_us = 0;
         constexpr int64_t kCooldownUs = 1200000;
         const int64_t now = esp_timer_get_time();
@@ -522,8 +500,7 @@ private:
         ShowTemporaryEmotion("happy", 2000);
     }
 
-    void PlayBatteryEmotion(const char* emotion, uint32_t duration_ms)
-    {
+    void PlayBatteryEmotion(const char* emotion, uint32_t duration_ms) {
 #if CONFIG_USE_EMOTE_MESSAGE_STYLE
         if (display_ == nullptr || emotion == nullptr) {
             return;
@@ -537,8 +514,7 @@ private:
         ShowTemporaryEmotion(emotion, duration_ms);
     }
 
-    void StartLowBatteryAlertSequence()
-    {
+    void StartLowBatteryAlertSequence() {
         constexpr int kMaxPlays = 3;
         constexpr int64_t kIntervalMs = 5 * 60 * 1000;
 
@@ -547,8 +523,7 @@ private:
         PlayBatteryEmotion("low_battery", 4000);
     }
 
-    void HandleBatteryEmotions()
-    {
+    void HandleBatteryEmotions() {
         if (charge_ == nullptr) {
             return;
         }
@@ -596,8 +571,7 @@ private:
         }
     }
 
-    static void battery_task(void* arg)
-    {
+    static void battery_task(void* arg) {
         auto* self = static_cast<EspVocat*>(arg);
         while (true) {
             if (self != nullptr && self->charge_ != nullptr) {
@@ -608,8 +582,7 @@ private:
         }
     }
 
-    static void imu_event_task(void* arg)
-    {
+    static void imu_event_task(void* arg) {
         auto* self = static_cast<EspVocat*>(arg);
         if (self == nullptr || !self->bmi270_ready_) {
             vTaskDelete(NULL);
@@ -632,9 +605,11 @@ private:
                     int shake_score = dx + dy + dz;
 
                     int64_t now_ms = esp_timer_get_time() / 1000;
-                    if (shake_score > kShakeDeltaThreshold && (now_ms - last_shake_ms) > kShakeCooldownMs) {
+                    if (shake_score > kShakeDeltaThreshold &&
+                        (now_ms - last_shake_ms) > kShakeCooldownMs) {
                         last_shake_ms = now_ms;
-                        // "dizzy/nauseated" are not guaranteed in current assets, use supported fallback.
+                        // "dizzy/nauseated" are not guaranteed in current assets, use supported
+                        // fallback.
                         self->ShowTemporaryEmotion("confused", 1800);
                     }
                 }
@@ -645,17 +620,17 @@ private:
         }
     }
 
-    void InitializeI2c()
-    {
+    void InitializeI2c() {
         i2c_config_t i2c_cfg = {
             .mode = I2C_MODE_MASTER,
             .sda_io_num = AUDIO_CODEC_I2C_SDA_PIN,
             .scl_io_num = AUDIO_CODEC_I2C_SCL_PIN,
             .sda_pullup_en = true,
             .scl_pullup_en = true,
-            .master = {
-                .clk_speed = 400000,
-            },
+            .master =
+                {
+                    .clk_speed = 400000,
+                },
             .clk_flags = 0,
         };
         shared_i2c_bus_handle_ = i2c_bus_create(I2C_NUM_0, &i2c_cfg);
@@ -677,54 +652,49 @@ private:
         ESP_ERROR_CHECK(temperature_sensor_install(&temp_sensor_config, &temp_sensor));
         ESP_ERROR_CHECK(temperature_sensor_enable(temp_sensor));
     }
-    uint8_t DetectPcbVersion()
-        {
-            gpio_config_t gpio_conf = {
-                .pin_bit_mask = (1ULL << CORDEC_POWER_CTRL),
-                .mode = GPIO_MODE_OUTPUT,
-                .pull_up_en = GPIO_PULLUP_DISABLE,
-                .pull_down_en = GPIO_PULLDOWN_DISABLE,
-                .intr_type = GPIO_INTR_DISABLE
-            };
-            ESP_ERROR_CHECK(gpio_config(&gpio_conf));
-            ESP_ERROR_CHECK(gpio_set_level(CORDEC_POWER_CTRL, 0));
+    uint8_t DetectPcbVersion() {
+        gpio_config_t gpio_conf = {.pin_bit_mask = (1ULL << CORDEC_POWER_CTRL),
+                                   .mode = GPIO_MODE_OUTPUT,
+                                   .pull_up_en = GPIO_PULLUP_DISABLE,
+                                   .pull_down_en = GPIO_PULLDOWN_DISABLE,
+                                   .intr_type = GPIO_INTR_DISABLE};
+        ESP_ERROR_CHECK(gpio_config(&gpio_conf));
+        ESP_ERROR_CHECK(gpio_set_level(CORDEC_POWER_CTRL, 0));
+        vTaskDelay(pdMS_TO_TICKS(50));
+
+        bool codec_alive = (i2c_master_probe(i2c_bus_, 0x18, 100) == ESP_OK);
+        uint8_t pcb_version = 0;
+        if (codec_alive) {
+            ESP_LOGI(TAG, "PCB version V1.0");
+            pcb_version = 0;
+        } else {
+            ESP_ERROR_CHECK(gpio_set_level(CORDEC_POWER_CTRL, 1));
             vTaskDelay(pdMS_TO_TICKS(50));
-
-            bool codec_alive = (i2c_master_probe(i2c_bus_, 0x18, 100) == ESP_OK);
-            uint8_t pcb_version = 0;
+            codec_alive = (i2c_master_probe(i2c_bus_, 0x18, 100) == ESP_OK);
             if (codec_alive) {
-                ESP_LOGI(TAG, "PCB version V1.0");
-                pcb_version = 0;
+                ESP_LOGI(TAG, "PCB version V1.2");
+                pcb_version = 1;
+                AUDIO_I2S_GPIO_DIN = AUDIO_I2S_GPIO_DIN_2;
+                AUDIO_CODEC_PA_PIN = AUDIO_CODEC_PA_PIN_2;
+                QSPI_PIN_NUM_LCD_RST = QSPI_PIN_NUM_LCD_RST_2;
+                TOUCH_PAD2 = TOUCH_PAD2_2;
+                UART1_TX = UART1_TX_2;
+                UART1_RX = UART1_RX_2;
             } else {
-                ESP_ERROR_CHECK(gpio_set_level(CORDEC_POWER_CTRL, 1));
-                vTaskDelay(pdMS_TO_TICKS(50));
-                codec_alive = (i2c_master_probe(i2c_bus_, 0x18, 100) == ESP_OK);
-                if (codec_alive) {
-                    ESP_LOGI(TAG, "PCB version V1.2");
-                    pcb_version = 1;
-                    AUDIO_I2S_GPIO_DIN = AUDIO_I2S_GPIO_DIN_2;
-                    AUDIO_CODEC_PA_PIN = AUDIO_CODEC_PA_PIN_2;
-                    QSPI_PIN_NUM_LCD_RST = QSPI_PIN_NUM_LCD_RST_2;
-                    TOUCH_PAD2 = TOUCH_PAD2_2;
-                    UART1_TX = UART1_TX_2;
-                    UART1_RX = UART1_RX_2;
-                } else {
-                    ESP_LOGE(TAG, "PCB version detection error");
-                }
+                ESP_LOGE(TAG, "PCB version detection error");
             }
-            return pcb_version;
         }
+        return pcb_version;
+    }
 
-    static void touch_isr_callback(void* arg)
-    {
+    static void touch_isr_callback(void* arg) {
         Cst816s* touchpad = static_cast<Cst816s*>(arg);
         if (touchpad != nullptr) {
             touchpad->NotifyTouchEvent();
         }
     }
 
-    static void touch_event_task(void* arg)
-    {
+    static void touch_event_task(void* arg) {
         Cst816s* touchpad = static_cast<Cst816s*>(arg);
         if (touchpad == nullptr) {
             ESP_LOGE(TAG, "Invalid touchpad pointer in touch_event_task");
@@ -734,8 +704,8 @@ private:
 
         while (true) {
             if (touchpad->WaitForTouchEvent()) {
-                auto &app = Application::GetInstance();
-                auto &board = (EspVocat &)Board::GetInstance();
+                auto& app = Application::GetInstance();
+                auto& board = (EspVocat&)Board::GetInstance();
 
                 ESP_LOGD(TAG, "Touch event, TP_PIN_NUM_INT: %d", gpio_get_level(TP_PIN_NUM_INT));
                 touchpad->UpdateTouchPoint();
@@ -752,44 +722,42 @@ private:
         }
     }
 
-    void InitializeCharge()
-    {
+    void InitializeCharge() {
         charge_ = new Charge(i2c_bus_, 0x55);
         was_charging_ = charge_->IsCharging();
-        xTaskCreatePinnedToCore(battery_task, "batteryTask", 3 * 1024, this, 6, &charge_task_handle_, 0);
+        xTaskCreatePinnedToCore(battery_task, "batteryTask", 3 * 1024, this, 6,
+                                &charge_task_handle_, 0);
     }
 
-    void InitializeCst816sTouchPad()
-    {
+    void InitializeCst816sTouchPad() {
         cst816s_ = new Cst816s(i2c_bus_, 0x15);
 
-        xTaskCreatePinnedToCore(touch_event_task, "touch_task", 4 * 1024, cst816s_, 5, &touch_task_handle_, 1);
+        xTaskCreatePinnedToCore(touch_event_task, "touch_task", 4 * 1024, cst816s_, 5,
+                                &touch_task_handle_, 1);
 
-        const gpio_config_t int_gpio_config = {
-            .pin_bit_mask = (1ULL << TP_PIN_NUM_INT),
-            .mode = GPIO_MODE_INPUT,
-            // .intr_type = GPIO_INTR_NEGEDGE
-            .intr_type = GPIO_INTR_ANYEDGE
-        };
+        const gpio_config_t int_gpio_config = {.pin_bit_mask = (1ULL << TP_PIN_NUM_INT),
+                                               .mode = GPIO_MODE_INPUT,
+                                               // .intr_type = GPIO_INTR_NEGEDGE
+                                               .intr_type = GPIO_INTR_ANYEDGE};
         gpio_config(&int_gpio_config);
         gpio_install_isr_service(0);
         gpio_intr_enable(TP_PIN_NUM_INT);
         gpio_isr_handler_add(TP_PIN_NUM_INT, EspVocat::touch_isr_callback, cst816s_);
     }
 
-    void InitializeBmi270()
-    {
+    void InitializeBmi270() {
         esp_err_t imu_ret = Bmi270Motion::Initialize(shared_i2c_bus_handle_);
         if (imu_ret == ESP_OK) {
             bmi270_ready_ = true;
-            xTaskCreatePinnedToCore(imu_event_task, "imu_task", 4 * 1024, this, 4, &imu_task_handle_, 1);
+            xTaskCreatePinnedToCore(imu_event_task, "imu_task", 4 * 1024, this, 4,
+                                    &imu_task_handle_, 1);
         } else {
             ESP_LOGW(TAG, "BMI270 unavailable, shake emotion disabled");
         }
     }
 
-    static uint32_t TouchChannelFromPadGpio(gpio_num_t gpio)
-    {
+#if ESP_VOCAT_ENABLE_CAP_TOUCH_SENSOR
+    static uint32_t TouchChannelFromPadGpio(gpio_num_t gpio) {
         if (gpio == GPIO_NUM_NC) {
             return 0;
         }
@@ -799,8 +767,9 @@ private:
         return 0;
     }
 
-    static void touch_slider_event_callback(touch_slider_handle_t handle, touch_slider_event_t event, int32_t data, void* cb_arg)
-    {
+    static void touch_slider_event_callback(touch_slider_handle_t handle,
+                                            touch_slider_event_t event, int32_t data,
+                                            void* cb_arg) {
         (void)handle;
         auto* self = static_cast<EspVocat*>(cb_arg);
         if (self == nullptr || self->display_ == nullptr) {
@@ -824,8 +793,8 @@ private:
         self->ShowHappyTouchFeedback();
     }
 
-    static void touch_button_event_callback(touch_button_handle_t handle, uint32_t channel, touch_state_t state, void* cb_arg)
-    {
+    static void touch_button_event_callback(touch_button_handle_t handle, uint32_t channel,
+                                            touch_state_t state, void* cb_arg) {
         (void)handle;
         auto* self = static_cast<EspVocat*>(cb_arg);
         if (self == nullptr || self->display_ == nullptr) {
@@ -837,8 +806,7 @@ private:
         }
     }
 
-    static void touch_cap_poll_task(void* arg)
-    {
+    static void touch_cap_poll_task(void* arg) {
         auto* self = static_cast<EspVocat*>(arg);
         while (true) {
             if (self != nullptr) {
@@ -852,8 +820,7 @@ private:
         }
     }
 
-    void InitializeCapacitiveTouchPads()
-    {
+    void InitializeCapacitiveTouchPads() {
         if (TOUCH_PAD1 == GPIO_NUM_NC) {
             ESP_LOGW(TAG, "Capacitive touch disabled: TOUCH_PAD1 NC");
             return;
@@ -861,7 +828,8 @@ private:
 
         const uint32_t ch1 = TouchChannelFromPadGpio(TOUCH_PAD1);
         if (ch1 == 0) {
-            ESP_LOGW(TAG, "TOUCH_PAD1 GPIO %d is not a touch channel (expect GPIO1..GPIO14)", (int)TOUCH_PAD1);
+            ESP_LOGW(TAG, "TOUCH_PAD1 GPIO %d is not a touch channel (expect GPIO1..GPIO14)",
+                     (int)TOUCH_PAD1);
             return;
         }
 
@@ -893,15 +861,18 @@ private:
                 .swipe_alpha = 0.9f,
                 .skip_lowlevel_init = false,
             };
-            esp_err_t err = touch_slider_sensor_create(&sld_cfg, &touch_slider_handle_, touch_slider_event_callback, this);
+            esp_err_t err = touch_slider_sensor_create(&sld_cfg, &touch_slider_handle_,
+                                                       touch_slider_event_callback, this);
             if (err != ESP_OK) {
                 ESP_LOGW(TAG, "touch_slider_sensor_create failed: %s", esp_err_to_name(err));
                 touch_slider_handle_ = nullptr;
                 return;
             }
-            xTaskCreatePinnedToCore(touch_cap_poll_task, "touch_cap", 3072, this, 3, &touch_slider_task_handle_, 1);
+            xTaskCreatePinnedToCore(touch_cap_poll_task, "touch_cap", 3072, this, 3,
+                                    &touch_slider_task_handle_, 1);
             ESP_LOGI(TAG, "Touch slider (PCB v1.2+): PAD1 GPIO%d ch%u, PAD2 GPIO%d ch%u",
-                     (int)TOUCH_PAD1, (unsigned)slider_ch[0], (int)TOUCH_PAD2, (unsigned)slider_ch[1]);
+                     (int)TOUCH_PAD1, (unsigned)slider_ch[0], (int)TOUCH_PAD2,
+                     (unsigned)slider_ch[1]);
             return;
         }
 
@@ -918,49 +889,51 @@ private:
             .debounce_times = 2,
             .skip_lowlevel_init = false,
         };
-        esp_err_t err = touch_button_sensor_create(&btn_cfg, &touch_button_handle_, touch_button_event_callback, this);
+        esp_err_t err = touch_button_sensor_create(&btn_cfg, &touch_button_handle_,
+                                                   touch_button_event_callback, this);
         if (err != ESP_OK) {
             ESP_LOGW(TAG, "touch_button_sensor_create failed: %s", esp_err_to_name(err));
             touch_button_handle_ = nullptr;
             return;
         }
-        xTaskCreatePinnedToCore(touch_cap_poll_task, "touch_cap", 3072, this, 3, &touch_slider_task_handle_, 1);
-        ESP_LOGI(TAG, "Touch button (PCB v1.0): TOUCH_PAD1 GPIO%d ch%u", (int)TOUCH_PAD1, (unsigned)btn_ch[0]);
+        xTaskCreatePinnedToCore(touch_cap_poll_task, "touch_cap", 3072, this, 3,
+                                &touch_slider_task_handle_, 1);
+        ESP_LOGI(TAG, "Touch button (PCB v1.0): TOUCH_PAD1 GPIO%d ch%u", (int)TOUCH_PAD1,
+                 (unsigned)btn_ch[0]);
     }
+#endif
 
-    void InitializeSpi()
-    {
-        const spi_bus_config_t bus_config = TAIJIPI_ST77916_PANEL_BUS_QSPI_CONFIG(QSPI_PIN_NUM_LCD_PCLK,
-                                                                                  QSPI_PIN_NUM_LCD_DATA0,
-                                                                                  QSPI_PIN_NUM_LCD_DATA1,
-                                                                                  QSPI_PIN_NUM_LCD_DATA2,
-                                                                                  QSPI_PIN_NUM_LCD_DATA3,
-                                                                                  QSPI_LCD_H_RES * 80 * sizeof(uint16_t));
+    void InitializeSpi() {
+        const spi_bus_config_t bus_config = TAIJIPI_ST77916_PANEL_BUS_QSPI_CONFIG(
+            QSPI_PIN_NUM_LCD_PCLK, QSPI_PIN_NUM_LCD_DATA0, QSPI_PIN_NUM_LCD_DATA1,
+            QSPI_PIN_NUM_LCD_DATA2, QSPI_PIN_NUM_LCD_DATA3, QSPI_LCD_H_RES * 80 * sizeof(uint16_t));
         ESP_ERROR_CHECK(spi_bus_initialize(QSPI_LCD_HOST, &bus_config, SPI_DMA_CH_AUTO));
     }
 
-    void InitializeSt77916Display(uint8_t pcb_version)
-    {
-
+    void InitializeSt77916Display(uint8_t pcb_version) {
         esp_lcd_panel_io_handle_t panel_io = nullptr;
         esp_lcd_panel_handle_t panel = nullptr;
 
-        const esp_lcd_panel_io_spi_config_t io_config = ST77916_PANEL_IO_QSPI_CONFIG(QSPI_PIN_NUM_LCD_CS, NULL, NULL);
-        ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)QSPI_LCD_HOST, &io_config, &panel_io));
+        const esp_lcd_panel_io_spi_config_t io_config =
+            ST77916_PANEL_IO_QSPI_CONFIG(QSPI_PIN_NUM_LCD_CS, NULL, NULL);
+        ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi((esp_lcd_spi_bus_handle_t)QSPI_LCD_HOST,
+                                                 &io_config, &panel_io));
         st77916_vendor_config_t vendor_config = {
             .init_cmds = vendor_specific_init_yysj,
             .init_cmds_size = sizeof(vendor_specific_init_yysj) / sizeof(st77916_lcd_init_cmd_t),
-            .flags = {
-                .use_qspi_interface = 1,
-            },
+            .flags =
+                {
+                    .use_qspi_interface = 1,
+                },
         };
         const esp_lcd_panel_dev_config_t panel_config = {
             .reset_gpio_num = QSPI_PIN_NUM_LCD_RST,
             .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,
             .bits_per_pixel = QSPI_LCD_BIT_PER_PIXEL,
-            .flags = {
-                .reset_active_high = pcb_version,
-            },
+            .flags =
+                {
+                    .reset_active_high = pcb_version,
+                },
             .vendor_config = &vendor_config,
         };
         ESP_ERROR_CHECK(esp_lcd_new_panel_st77916(panel_io, &panel_config, &panel));
@@ -974,17 +947,17 @@ private:
 #if CONFIG_USE_EMOTE_MESSAGE_STYLE
         display_ = new emote::EmoteDisplay(panel, panel_io, DISPLAY_WIDTH, DISPLAY_HEIGHT);
 #else
-        display_ = new SpiLcdDisplay(panel_io, panel,
-            DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
+        display_ = new SpiLcdDisplay(panel_io, panel, DISPLAY_WIDTH, DISPLAY_HEIGHT,
+                                     DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y, DISPLAY_MIRROR_X,
+                                     DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
 #endif
         backlight_ = new PwmBacklight(DISPLAY_BACKLIGHT_PIN, DISPLAY_BACKLIGHT_OUTPUT_INVERT);
         backlight_->RestoreBrightness();
     }
 
-    void InitializeButtons()
-    {
+    void InitializeButtons() {
         boot_button_.OnClick([this]() {
-            auto &app = Application::GetInstance();
+            auto& app = Application::GetInstance();
             if (app.GetDeviceState() == kDeviceStateStarting) {
                 ESP_LOGI(TAG, "Boot button pressed, enter WiFi configuration mode");
                 EnterWifiConfigMode();
@@ -1005,18 +978,20 @@ private:
 #ifdef CONFIG_ESP_VIDEO_ENABLE_USB_UVC_VIDEO_DEVICE
     void InitializeCamera() {
         esp_video_init_usb_uvc_config_t usb_uvc_config = {
-            .uvc = {
-                .uvc_dev_num = 1,
-                .task_stack = 4096,
-                .task_priority = 5,
-                .task_affinity = -1,
-            },
-            .usb = {
-                .init_usb_host_lib = true,
-                .task_stack = 4096,
-                .task_priority = 5,
-                .task_affinity = -1,
-            },
+            .uvc =
+                {
+                    .uvc_dev_num = 1,
+                    .task_stack = 4096,
+                    .task_priority = 5,
+                    .task_affinity = -1,
+                },
+            .usb =
+                {
+                    .init_usb_host_lib = true,
+                    .task_stack = 4096,
+                    .task_priority = 5,
+                    .task_affinity = -1,
+                },
         };
 
         esp_video_init_config_t video_config = {
@@ -1025,7 +1000,7 @@ private:
 
         camera_ = new EspVideo(video_config);
     }
-#endif // CONFIG_ESP_VIDEO_ENABLE_USB_UVC_VIDEO_DEVICE
+#endif  // CONFIG_ESP_VIDEO_ENABLE_USB_UVC_VIDEO_DEVICE
 
 public:
     ~EspVocat() {
@@ -1039,6 +1014,7 @@ public:
         if (imu_task_handle_ != nullptr) {
             vTaskDelete(imu_task_handle_);
         }
+#if ESP_VOCAT_ENABLE_CAP_TOUCH_SENSOR
         if (touch_slider_task_handle_ != nullptr) {
             vTaskDelete(touch_slider_task_handle_);
             touch_slider_task_handle_ = nullptr;
@@ -1051,6 +1027,7 @@ public:
             touch_button_sensor_delete(touch_button_handle_);
             touch_button_handle_ = nullptr;
         }
+#endif
 
         // Delete objects
         delete charge_;
@@ -1076,8 +1053,7 @@ public:
         }
     }
 
-    EspVocat() : boot_button_(BOOT_BUTTON_GPIO)
-    {
+    EspVocat() : boot_button_(BOOT_BUTTON_GPIO) {
         const esp_timer_create_args_t emotion_timer_args = {
             .callback = &EspVocat::emotion_reset_timer_callback,
             .arg = this,
@@ -1096,48 +1072,30 @@ public:
         InitializeSpi();
         InitializeSt77916Display(pcb_version);
         InitializeButtons();
+#if ESP_VOCAT_ENABLE_CAP_TOUCH_SENSOR
         InitializeCapacitiveTouchPads();
+#endif
 #ifdef CONFIG_ESP_VIDEO_ENABLE_USB_UVC_VIDEO_DEVICE
         InitializeCamera();
-#endif // CONFIG_ESP_VIDEO_ENABLE_USB_UVC_VIDEO_DEVICE
+#endif  // CONFIG_ESP_VIDEO_ENABLE_USB_UVC_VIDEO_DEVICE
     }
 
-    virtual AudioCodec* GetAudioCodec() override
-    {
+    virtual AudioCodec* GetAudioCodec() override {
         static BoxAudioCodec audio_codec(
-            i2c_bus_,
-            AUDIO_INPUT_SAMPLE_RATE,
-            AUDIO_OUTPUT_SAMPLE_RATE,
-            AUDIO_I2S_GPIO_MCLK,
-            AUDIO_I2S_GPIO_BCLK,
-            AUDIO_I2S_GPIO_WS,
-            AUDIO_I2S_GPIO_DOUT,
-            AUDIO_I2S_GPIO_DIN,
-            AUDIO_CODEC_PA_PIN,
-            AUDIO_CODEC_ES8311_ADDR,
-            AUDIO_CODEC_ES7210_ADDR,
+            i2c_bus_, AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE, AUDIO_I2S_GPIO_MCLK,
+            AUDIO_I2S_GPIO_BCLK, AUDIO_I2S_GPIO_WS, AUDIO_I2S_GPIO_DOUT, AUDIO_I2S_GPIO_DIN,
+            AUDIO_CODEC_PA_PIN, AUDIO_CODEC_ES8311_ADDR, AUDIO_CODEC_ES7210_ADDR,
             AUDIO_INPUT_REFERENCE);
         return &audio_codec;
     }
 
-    virtual Display* GetDisplay() override
-    {
-        return display_;
-    }
+    virtual Display* GetDisplay() override { return display_; }
 
-    Cst816s* GetTouchpad()
-    {
-        return cst816s_;
-    }
+    Cst816s* GetTouchpad() { return cst816s_; }
 
-    virtual Backlight* GetBacklight() override
-    {
-        return backlight_;
-    }
+    virtual Backlight* GetBacklight() override { return backlight_; }
 
-    virtual Camera* GetCamera() override {
-        return camera_;
-    }
+    virtual Camera* GetCamera() override { return camera_; }
 
     virtual bool GetBatteryLevel(int& level, bool& charging, bool& discharging) override {
         if (charge_ == nullptr) {

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -126,12 +126,15 @@ dependencies:
   espressif/touch_slider_sensor:
     version: ^0.2.0~1
     rules:
+    # The conditions specified in 'rules' with 'if' are combined with 'and'
     - if: target in [esp32s3]
+    - if: idf_version < 6.0.0
 
   espressif/touch_button_sensor:
     version: ^0.2.2~1
     rules:
     - if: target in [esp32s3]
+    - if: idf_version < 6.0.0
 
   espressif/esp_lcd_touch_st7123: ^1.0.0
   espressif/iot_usbh_rndis: 


### PR DESCRIPTION
Some components required by the touch sensor feature are currently being adapted for IDF v6. Therefore, touch sensor-related components are temporarily excluded from IDF v6 builds. In addition, the ESP-VoCat touch sensor feature is temporarily disabled when building with IDF v6.

CC @almirus , as this feature was originally introduced in your PR #1902 .