### PR TITLE
feat(otto): update GIF emoji component to v1.3.0

### DIFF
--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -63,7 +63,7 @@ dependencies:
   espressif2022/esp_emote_expression: ^0.1.0
   espressif/esp_mmap_assets: ^1.3.2
   txp666/otto-emoji-gif-component:
-    version: ^1.1.1
+    version: ^1.3.0
     rules:
     - if: target in [esp32s3]
   espressif/adc_battery_estimation: ^0.2.1

--- a/scripts/build_default_assets.py
+++ b/scripts/build_default_assets.py
@@ -222,19 +222,6 @@ def process_emoji_collection(emoji_collection_dir, assets_dir):
     
     emoji_list = []
     
-    # Check if this is otto-gif collection
-    is_otto_gif = 'otto-emoji-gif-component' in emoji_collection_dir or emoji_collection_dir.endswith('otto-gif')
-    
-    # Otto GIF emoji aliases mapping
-    otto_gif_aliases = {
-        "staticstate": ["neutral", "relaxed", "sleepy", "idle"],
-        "happy": ["laughing", "funny", "loving", "confident", "winking", "cool", "delicious", "kissy", "silly"],
-        "sad": ["crying"],
-        "anger": ["angry"],
-        "scare": ["surprised", "shocked"],
-        "buxue": ["thinking", "confused", "embarrassed"]
-    }
-    
     # Copy each image from input directory to build/assets directory
     for root, dirs, files in os.walk(emoji_collection_dir):
         for file in files:
@@ -252,13 +239,6 @@ def process_emoji_collection(emoji_collection_dir, assets_dir):
                         "file": file
                     })
                     
-                    # Add aliases for otto-gif emojis
-                    if is_otto_gif and filename_without_ext in otto_gif_aliases:
-                        for alias in otto_gif_aliases[filename_without_ext]:
-                            emoji_list.append({
-                                "name": alias,
-                                "file": file
-                            })
     
     return emoji_list
 


### PR DESCRIPTION
## Summary

- Upgrade the Otto GIF emoji component to v1.3.0
- Remove legacy Otto GIF emotion alias mappings
- Use the 21 standard Xiaozhi emotion names directly

The new component provides one GIF for every standard Xiaozhi emotion name, so the asset builder no longer needs compatibility aliases. This also prevents duplicate emotion entries from being generated.

## Validation

- Confirmed the remote component resolves to v1.3.0 from Espressif Component Registry
- Confirmed all 21 standard emotion names are present with no differences
