### PR TITLE
fix(taiji-pi-s3): keep round-screen text in safe area

### DIFF
--- a/main/boards/taiji-pi-s3/config.h
+++ b/main/boards/taiji-pi-s3/config.h
@@ -44,6 +44,11 @@
 #define DISPLAY_OFFSET_X  0
 #define DISPLAY_OFFSET_Y  0
 
+// Round screen UI safe area (360x360)
+#define DISPLAY_STATUS_BAR_TOP_OFFSET 15
+#define DISPLAY_CHAT_BAR_WIDTH        250
+#define DISPLAY_CHAT_BAR_BOTTOM_OFFSET 40
+
 #define TP_PORT             (I2C_NUM_1)
 #define TP_PIN_NUM_TP_SDA   (GPIO_NUM_7)
 #define TP_PIN_NUM_TP_SCL   (GPIO_NUM_8)

--- a/main/boards/taiji-pi-s3/taiji_pi_s3.cc
+++ b/main/boards/taiji-pi-s3/taiji_pi_s3.cc
@@ -15,6 +15,28 @@
 
 #define TAG "TaijiPiS3Board"
 
+class TaijiPiS3Display : public SpiLcdDisplay {
+public:
+    using SpiLcdDisplay::SpiLcdDisplay;
+
+    void SetupUI() override {
+        SpiLcdDisplay::SetupUI();
+        DisplayLockGuard lock(this);
+
+        lv_obj_align(status_bar_, LV_ALIGN_TOP_MID, 0, DISPLAY_STATUS_BAR_TOP_OFFSET);
+
+        if (bottom_bar_ != nullptr && chat_message_label_ != nullptr) {
+            lv_obj_set_width(bottom_bar_, DISPLAY_CHAT_BAR_WIDTH);
+            lv_obj_align(bottom_bar_, LV_ALIGN_BOTTOM_MID, 0, -DISPLAY_CHAT_BAR_BOTTOM_OFFSET);
+
+            const lv_coord_t horizontal_padding =
+                lv_obj_get_style_pad_left(bottom_bar_, LV_PART_MAIN) +
+                lv_obj_get_style_pad_right(bottom_bar_, LV_PART_MAIN);
+            lv_obj_set_width(chat_message_label_, DISPLAY_CHAT_BAR_WIDTH - horizontal_padding);
+        }
+    }
+};
+
 static const st77916_lcd_init_cmd_t lcd_init_cmds[] = {
 #ifdef CONFIG_TAIJIPAI_I2S_TYPE_STD
     {0xF0, (uint8_t[]){0x08}, 1, 0},
@@ -595,8 +617,9 @@ private:
         esp_lcd_panel_swap_xy(panel, DISPLAY_SWAP_XY);
         esp_lcd_panel_mirror(panel, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y);
 
-        display_ = new SpiLcdDisplay(panel_io, panel,
-                                    DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
+        display_ = new TaijiPiS3Display(panel_io, panel, DISPLAY_WIDTH, DISPLAY_HEIGHT,
+                                       DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y, DISPLAY_MIRROR_X,
+                                       DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
     }
 
     void InitializeMute() {


### PR DESCRIPTION
## Summary

- add a Taiji Pi S3-specific display subclass for its 360x360 round panel
- constrain the chat bar to a 250 px safe width and move it 40 px above the bottom edge
- move the status bar 15 px below the top edge
- keep the change board-local so rectangular displays are unaffected

## Background

On the Taiji Pi S3 round display, the default full-width bottom chat bar extends into the clipped corners, making subtitle text partially unreadable. This follows the board-specific round-display approach already used by SenseCAP Watcher and M5Stack Stopwatch.

Related to #1470. Reproduction details and the proposed values were posted in the issue discussion.

## Hardware comparison

| Before | After |
| --- | --- |
| <img src="https://github.com/user-attachments/assets/16543dcc-b478-4447-ae3e-505ff972e2b1" width="480" alt="Subtitle clipped by the round display edge before the fix"> | <img src="https://github.com/user-attachments/assets/a19f2c5b-738c-4668-9f97-3f124bfe6766" width="480" alt="Bottom text moved into the round display safe area after the fix"> |
| The default full-width bottom text extends into the clipped edge of the round panel. | The bottom bar is constrained to a 250 px width and shifted 40 px upward into the visible safe area. |

## Validation

- `python3 -m unittest discover -s scripts/tests -v` (8 tests passed)
- ESP-IDF 6.0.2: built `taiji-pi-s3` successfully
- ESP-IDF 6.0.2: built `taiji-pi-s3-pdm` successfully
- flashed the exact PR build to a physical Taiji Pi S3 with a 360x360 ST77916 round panel
- verified v2.4.0 boot, ST77916/LVGL initialization, assets, PSRAM, and stable runtime over serial
