### PR TITLE
Update ESP-SR/P4 support and fix LCDWiki IDF 6 build

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ As a voice interaction entry, the XiaoZhi AI chatbot leverages the AI capabiliti
 
 ## Recent Updates
 
-- The mainline now targets ESP-IDF v6.0 or later, with v6.0.2 as the preferred stable SDK. The complete 157-variant release matrix has been validated on ESP-IDF v6.0.1.
+- The mainline now targets ESP-IDF v6.0 or later, with v6.0.2 as the preferred stable SDK. The previous 157-variant baseline was validated on ESP-IDF v6.0.1; the current matrix contains 172 variants after enabling ESP32-P4 Rev < 3 builds with ESP-SR 2.4.7.
 - MQTT and BluFi cryptographic code has migrated to PSA Crypto. IDF 6 component splits and third-party dependency compatibility have also been addressed.
 - Audio pipeline concurrency, MQTT/UDP packet validation, and release-matrix selection have been hardened.
-- ESP-IDF v5.5 is retained only for legacy hardware paths, including pre-v3 ESP32-P4 silicon. See the [ESP-IDF 6.0 Migration Guide](docs/esp-idf-6-migration.md) for full compatibility and board-validation details.
+- ESP-IDF v5.5 is retained only for documented legacy boards. ESP32-P4 Rev1 and Rev3 are both supported on IDF 6 with ESP-SR 2.4.7; see the [ESP-IDF 6.0 Migration Guide](docs/esp-idf-6-migration.md) for full compatibility and board-validation details.
 
 ### Features Implemented
 
@@ -47,7 +47,7 @@ Breadboard demo:
 
 ![Breadboard Demo](docs/v1/wiring2.jpg)
 
-### Supports 137 Board Directories and 157 Release Variants (Partial List)
+### Supports 138 Board Directories and 172 Release Variants (Partial List)
 
 - <a href="https://oshwhub.com/li-chuang-kai-fa-ban/li-chuang-shi-zhan-pai-esp32-s3-kai-fa-ban" target="_blank" title="LiChuang ESP32-S3 Development Board">LiChuang ESP32-S3 Development Board</a>
 - <a href="https://github.com/espressif/esp-box" target="_blank" title="Espressif ESP32-S3-BOX3">Espressif ESP32-S3-BOX3</a>

--- a/README_ja.md
+++ b/README_ja.md
@@ -14,10 +14,10 @@
 
 ## 最近の更新
 
-- メインラインはESP-IDF v6.0以降へ移行し、推奨安定版はv6.0.2です。全157リリースバリアントはESP-IDF v6.0.1でビルド検証済みです。
+- メインラインはESP-IDF v6.0以降へ移行し、推奨安定版はv6.0.2です。従来の157リリースバリアントはESP-IDF v6.0.1でビルド検証済みで、ESP-SR 2.4.7によってESP32-P4 Rev < 3を有効化した現在のマトリクスは172バリアントです。
 - MQTTとBluFiの暗号処理をPSA Cryptoへ移行し、IDF 6のコンポーネント分割およびサードパーティ依存関係にも対応しました。
 - オーディオパイプラインの並行処理、MQTT/UDPパケット検証、リリースマトリクス選択処理を強化しました。
-- ESP-IDF v5.5は、ESP32-P4 v3より前のシリコンを含む旧ハードウェア互換用途にのみ残しています。詳細な互換性とボード検証状況は、[ESP-IDF 6.0移行ガイド](docs/esp-idf-6-migration.md)を参照してください。
+- ESP-IDF v5.5は、文書で明記された旧式ボード向けにのみ残しています。ESP-SR 2.4.7を使用すると、ESP32-P4 Rev1とRev3の両方がIDF 6に対応します。詳細な互換性とボード検証状況は、[ESP-IDF 6.0移行ガイド](docs/esp-idf-6-migration.md)を参照してください。
 
 ### 実装済み機能
 
@@ -47,7 +47,7 @@ Feishuドキュメントチュートリアルをご覧ください：
 
 ![ブレッドボードデモ](docs/v1/wiring2.jpg)
 
-### 137のボードディレクトリと157のリリースバリアントに対応（一部のみ表示）
+### 138のボードディレクトリと172のリリースバリアントに対応（一部のみ表示）
 
 - <a href="https://oshwhub.com/li-chuang-kai-fa-ban/li-chuang-shi-zhan-pai-esp32-s3-kai-fa-ban" target="_blank" title="立創・実戦派 ESP32-S3 開発ボード">立創・実戦派 ESP32-S3 開発ボード</a>
 - <a href="https://github.com/espressif/esp-box" target="_blank" title="楽鑫 ESP32-S3-BOX3">楽鑫 ESP32-S3-BOX3</a>

--- a/README_zh.md
+++ b/README_zh.md
@@ -14,10 +14,10 @@
 
 ## 近期更新
 
-- 项目主线现已迁移到 ESP-IDF v6.0 或以上版本，首选稳定版为 v6.0.2；完整的 157 个发布变体已在 ESP-IDF v6.0.1 上通过构建验证。
+- 项目主线现已迁移到 ESP-IDF v6.0 或以上版本，首选稳定版为 v6.0.2；此前的 157 个发布变体已在 ESP-IDF v6.0.1 上通过构建验证，使用 ESP-SR 2.4.7 启用 ESP32-P4 Rev < 3 后，当前矩阵包含 172 个变体。
 - MQTT 和 BluFi 加密已迁移到 PSA Crypto，同时完成了 IDF 6 组件拆分及第三方依赖兼容处理。
 - 加固了音频流水线并发、MQTT/UDP 数据包校验和发布矩阵选择逻辑。
-- ESP-IDF v5.5 仅保留用于旧版硬件兼容，包括 ESP32-P4 v3 之前的芯片版本。完整兼容性和板卡验证状态请参阅 [ESP-IDF 6.0 迁移文档](docs/esp-idf-6-migration.md)。
+- ESP-IDF v5.5 仅保留用于文档明确标注的旧版板卡；使用 ESP-SR 2.4.7 时，ESP32-P4 Rev1 和 Rev3 均支持 IDF 6。完整兼容性和板卡验证状态请参阅 [ESP-IDF 6.0 迁移文档](docs/esp-idf-6-migration.md)。
 
 ### 已实现功能
 
@@ -47,7 +47,7 @@
 
 ![面包板效果图](docs/v1/wiring2.jpg)
 
-### 支持 137 个板卡目录、157 个固件发布变体（仅展示部分）
+### 支持 138 个板卡目录、172 个固件发布变体（仅展示部分）
 
 - <a href="https://oshwhub.com/li-chuang-kai-fa-ban/li-chuang-shi-zhan-pai-esp32-s3-kai-fa-ban" target="_blank" title="立创·实战派 ESP32-S3 开发板">立创·实战派 ESP32-S3 开发板</a>
 - <a href="https://github.com/espressif/esp-box" target="_blank" title="乐鑫 ESP32-S3-BOX3">乐鑫 ESP32-S3-BOX3</a>

--- a/docs/esp-idf-6-migration.md
+++ b/docs/esp-idf-6-migration.md
@@ -1,20 +1,21 @@
 # ESP-IDF 6.0 Migration and Board Compatibility Status
 
-> Last updated: 2026-07-17
+> Last updated: 2026-07-24
 > Validated SDK: ESP-IDF v6.0.1
-> Scope: 137 board directories and 157 supported build variants defined by `main/boards/**/config.json`.
+> Scope: 138 board directories and 172 supported build variants defined by `main/boards/**/config.json`.
 
 ## Current Status
 
-All 157 IDF 6 variants are build-compatible with ESP-IDF 6.0.1 and passed the latest complete GitHub Actions matrix. Fourteen legacy ESP32-P4 Rev < 3 variants are excluded from the IDF 6 matrix but remain available when building with ESP-IDF < 6. Component versions that use ranges are resolved from the Component Registry at build time; until per-target lock snapshots are committed, this is a source-reproducible build rather than a bit-for-bit dependency-reproducible build.
+The current IDF 6 release selection contains 172 variants. The previous 157-variant baseline passed the latest complete GitHub Actions matrix on ESP-IDF 6.0.1. ESP-SR 2.4.7 adds IDF 6 support for ESP32-P4 Rev < 3, so the 14 unsuffixed Rev1 variants now join their existing `-p4x` Rev3 counterparts in the IDF 6 matrix. Component versions that use ranges are resolved from the Component Registry at build time; until per-target lock snapshots are committed, this is a source-reproducible build rather than a bit-for-bit dependency-reproducible build.
 
 | Status | Variants | Meaning |
 |---|---:|---|
-| ✅ Build-compatible | 157 | All 157 full builds completed in GitHub Actions with ESP-IDF 6.0.1; this does not imply hardware or complete peripheral validation |
+| ✅ Previously matrix-validated | 157 | All 157 baseline builds completed in GitHub Actions with ESP-IDF 6.0.1; this does not imply hardware or complete peripheral validation |
+| 🟡 Added since full-matrix validation | 15 | Includes the 14 newly enabled P4 Rev1 variants; representative validation is recorded below and a complete 172-variant CI run remains pending |
 | 🟡 Feature-degraded subset | 1 | `esp-vocat` builds on IDF 6, but its PCB capacitive slider/button support is disabled pending compatible touch-sensor components |
 | 🔴 Build-blocked | 0 | No supported release variant remains blocked at compile or link time |
 
-There are no remaining IDF 6 build blockers. [`78/esp_lcd_nv3023 1.0.1`](https://components.espressif.com/components/78/esp_lcd_nv3023/versions/1.0.1) and [`wvirgil123/sscma_client 1.0.3`](https://components.espressif.com/components/wvirgil123/sscma_client/versions/1.0.3/readme) are consumed directly from the Component Registry, so local copies under the ignored `components/` directory are not required. ESP32-P4 Rev < 3 remains on the ESP-IDF 5.5 legacy build path, while the IDF 6 matrix supports ESP32-P4 v3.x.
+There are no known remaining IDF 6 build blockers. [`78/esp_lcd_nv3023 1.0.1`](https://components.espressif.com/components/78/esp_lcd_nv3023/versions/1.0.1) and [`wvirgil123/sscma_client 1.0.3`](https://components.espressif.com/components/wvirgil123/sscma_client/versions/1.0.3/readme) are consumed directly from the Component Registry, so local copies under the ignored `components/` directory are not required. ESP32-P4 Rev1 and Rev3 now share the IDF 6 build path while retaining separate artifact names and silicon-selection settings.
 
 Representative local full-build results are shown below. Firmware size and free space are reported by ESP-IDF 6.0.1 `check_sizes.py`. The authoritative per-variant compatibility result is the full GitHub Actions matrix in the next section.
 
@@ -33,16 +34,17 @@ Representative local full-build results are shown below. Firmware size and free 
 | ESP32-S3 | `otto-robot` | `0x37ff70` | 11% |
 | ESP32-S3 | `esp-vocat` | `0x2742f0` | 38% |
 | ESP32-S3 | `sensecap-watcher` | `0x2faff0` | 25% |
-| ESP32-P4 v3.x | `esp-p4-function-ev-board-p4x` | `0x385420` | 11% |
+| ESP32-P4 Rev1 | `esp-p4-function-ev-board` | `0x345a90` | 17% |
+| ESP32-P4 Rev3 | `esp-p4-function-ev-board-p4x` | `0x34a150` | 16% |
 | ESP32-P4 v3.x | `m5stack-tab5-p4x` | `0x380790` | 11% |
 
-As a negative test, `esp-p4-function-ev-board` (legacy P4 Rev < 3) was rejected as expected by `esp-sr 2.4.6` during IDF 6.0.1 configuration. Legacy P4 variants are therefore version-gated to ESP-IDF < 6 instead of being carried as permanent IDF 6 blockers.
+The old negative result for `esp-p4-function-ev-board` came from ESP-SR 2.4.6. ESP-SR 2.4.7 supplies the missing ESP32-P4 Rev < 3 libraries for IDF 6, so the project no longer version-gates the unsuffixed P4 variants.
 
 For backward-compatibility regression coverage, `xmini-c3` also completed a full build with ESP-IDF 5.5.4 (application size `0x234920`, 44% free in the smallest app partition). The legacy `esp-p4-function-ev-board` release variant subsequently completed the same 5.5.4 release flow (application size `0x38a130`, 10% free), including merged-binary packaging. This confirms that the compatibility changes for I2S port numbering, LCD I2C configuration, the UHCI DMA dependency, and the pre-v3 P4 selection did not break the existing 5.5 build chain.
 
 ## Full-Matrix CI Validation
 
-GitHub Actions run [29534954031](https://github.com/78/xiaozhi-esp32/actions/runs/29534954031) built the complete matrix with the `espressif/idf:v6.0.1` container. The matrix-generation job and all 157 board builds passed.
+GitHub Actions run [29534954031](https://github.com/78/xiaozhi-esp32/actions/runs/29534954031) built the then-current matrix with the `espressif/idf:v6.0.1` container. The matrix-generation job and all 157 board builds passed. This historical run predates the 172-variant matrix.
 
 Results by chip target:
 
@@ -60,14 +62,14 @@ Results by chip target:
 
 ## ESP32-P4 Silicon Scope and Naming
 
-The IDF 6 release matrix supports only ESP32-P4 v3.x silicon. Each legacy Rev < 3 build keeps its original name and contains `idf_version: "<6.0"`. Variant selection behaves as follows:
+The IDF 6 release matrix supports both ESP32-P4 Rev < 3 and Rev >= 3 silicon. The two silicon families keep distinct artifact names and sdkconfig settings:
 
 | SDK | ESP32-P4 Rev < 3 | ESP32-P4 Rev >= 3 |
 |---|---|---|
 | ESP-IDF < 6 | Original name without a suffix; adds `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` and `CONFIG_ESP32P4_REV_MIN_100=y` | Original name plus `-p4x` |
-| ESP-IDF >= 6 | Not listed or built | `-p4x` |
+| ESP-IDF >= 6 | Original name without a suffix; adds `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` and `CONFIG_ESP32P4_REV_MIN_100=y` | Original name plus `-p4x` |
 
-This restores the historical artifact names and keeps the IDF 6 matrix at 157 variants. The IDF 5.5 selection contains 171 variants: 14 P4 `-p4x` artifacts, 14 legacy-P4 artifacts with their original unsuffixed names, and 143 non-P4 variants.
+Both ESP-IDF 5.5 and ESP-IDF 6 now select 172 variants: 14 P4 `-p4x` artifacts, 14 Rev < 3 P4 artifacts with their original unsuffixed names, and 144 non-P4 variants.
 
 Espressif's current chip-identification table lists v0.0, v1.0, v1.3, v3.0, v3.1, and v3.2, with no v4.0 revision. The public errata history added v3.0/v3.1 information on 2026-02-12 and v3.2 information on 2026-04-20. ESP-IDF 6.0 release notes explicitly describe support for "ESP32-P4 Version3 silicon." See the official [chip revision identification](https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32p4/01-chip-identification/index.html), [errata revision history](https://docs.espressif.com/projects/esp-chip-errata/en/latest/esp32p4/revision-history/index.html), and [ESP-IDF releases](https://github.com/espressif/esp-idf/releases).
 
@@ -94,7 +96,7 @@ Espressif's current chip-identification table lists v0.0, v1.0, v1.3, v3.0, v3.1
 | BluFi security negotiation (conditional path) | PSA FFDH + SHA-256 + AES-CTR | ✅ Ported | Uses the ESP-IDF 6 security scheme with ffdhe3072 and passed local full ESP32-S3 builds with BluFi enabled on IDF 5.5.4 and 6.0.1. Legacy 1024-bit BluFi clients are not compatible and must be upgraded |
 | `espressif/bmi270_sensor` | [`0.1.2`](https://components.espressif.com/components/espressif/bmi270_sensor/versions/0.1.2/readme?language=en) | ✅ Upstream support | Provides IDF 6.0 prebuilt libraries for ESP32-C5 and ESP32-S3; validated by a full `esp-spot-c5` build |
 | `touch_slider_sensor` / `touch_button_sensor` | Disabled for IDF 6 | 🟡 Feature gap | Their manifests require IDF < 6.0, so ESP Vocat omits its PCB capacitive slider/button path on IDF 6. CST816 display touch is unaffected |
-| ESP32-P4 Rev < 3 / `espressif/esp-sr` | Version-gated to IDF < 6 | 🟡 Legacy SDK path | The 14 legacy variants are restored for IDF 5.5 builds. They remain excluded from IDF 6 because `esp-sr 2.4.6` rejects the old-silicon configuration; ESP32-P4 v3.x is unaffected |
+| ESP32-P4 Rev < 3 / `espressif/esp-sr` | `~2.4.7` | ✅ Upstream support | The 14 unsuffixed Rev1 variants are available on IDF 5.5 and IDF 6; `-p4x` continues to select Rev >= 3 |
 
 ## Per-Board Progress
 
@@ -234,7 +236,7 @@ In the table below, "Board" is the source directory and "Build variant" is the f
 | `esp32s3` | `zhengchen-1.54tft-wifi` | `zhengchen-1.54tft-wifi` | ✅ Full build passed | GitHub Actions IDF 6.0.1 full build | Hardware smoke/peripheral regression pending |
 | `esp32s3` | `zhengchen-cam` | `zhengchen-cam` | ✅ Full build passed | GitHub Actions IDF 6.0.1 full build | Hardware smoke/peripheral regression pending |
 | `esp32s3` | `zhengchen-cam-ml307` | `zhengchen-cam-ml307` | ✅ Full build passed | GitHub Actions IDF 6.0.1 full build | Hardware smoke/peripheral regression pending |
-| `esp32p4` | `esp-p4-function-ev-board` | `esp-p4-function-ev-board-p4x` | ✅ Full build passed | IDF 6.0.1 `idf.py build` | Hardware smoke/peripheral regression pending |
+| `esp32p4` | `esp-p4-function-ev-board` | `esp-p4-function-ev-board`<br>`esp-p4-function-ev-board-p4x` | ✅ Full builds passed | IDF 6.0.1 canonical release builds with ESP-SR 2.4.7 for Rev1 and Rev3 | Hardware smoke/peripheral regression pending |
 | `esp32p4` | `m5stack-tab5` | `m5stack-tab5-p4x` | ✅ Full build passed | GitHub Actions IDF 6.0.1 full build | Hardware smoke/peripheral regression pending |
 | `esp32p4` | `waveshare/esp32-p4-nano` | `waveshare-esp32-p4-nano-10.1-a-p4x` | ✅ Full build passed | GitHub Actions IDF 6.0.1 full build | Hardware smoke/peripheral regression pending |
 | `esp32p4` | `waveshare/esp32-p4-wifi6-touch-lcd` | `waveshare-esp32-p4-wifi6-touch-lcd-4b-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-4.3-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-5-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-7b-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-3.4c-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-4c-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-7-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-8-p4x`<br>`waveshare-esp32-p4-wifi6-touch-lcd-10.1-p4x` | ✅ Full build passed | GitHub Actions IDF 6.0.1 full build | Hardware smoke/peripheral regression pending |

--- a/main/boards/esp-p4-function-ev-board/config.json
+++ b/main/boards/esp-p4-function-ev-board/config.json
@@ -3,7 +3,6 @@
     "builds": [
         {
             "name": "esp-p4-function-ev-board",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SLAVE_IDF_TARGET_ESP32C6=y",
                 "CONFIG_ESP_HOSTED_P4_DEV_BOARD_FUNC_BOARD=y",

--- a/main/boards/lcdwiki-es3c35p/lcdwiki-es3c35p.cc
+++ b/main/boards/lcdwiki-es3c35p/lcdwiki-es3c35p.cc
@@ -1,47 +1,52 @@
-#include "wifi_board.h"
-#include "codecs/es8311_audio_codec.h"
-#include "display/lcd_display.h"
 #include "application.h"
 #include "button.h"
+#include "codecs/es8311_audio_codec.h"
 #include "config.h"
-#include "mcp_server.h"
+#include "display/lcd_display.h"
 #include "led/single_led.h"
+#include "mcp_server.h"
+#include "wifi_board.h"
 
-#include <esp_log.h>
 #include <driver/i2c_master.h>
 #include <driver/spi_common.h>
 #include <esp_lcd_panel_io.h>
 #include <esp_lcd_panel_ops.h>
 #include <esp_lcd_st77922.h>
+#include <esp_log.h>
 #include <esp_lvgl_port.h>
 #include <lvgl.h>
 
 #define TAG "LCDWikiES3C35P"
 
 // ---- ST77922 touch controller (I2C addr 0x55, FT6336G-compatible) ----
-#define TOUCH_I2C_ADDR          0x55
-#define TOUCH_REG_INFO           0x0010
-#define TOUCH_REG_MAX_TOUCHES    0x0009
-#define TOUCH_REG_POINT0         0x0014
+#define TOUCH_I2C_ADDR 0x55
+#define TOUCH_REG_INFO 0x0010
+#define TOUCH_REG_MAX_TOUCHES 0x0009
+#define TOUCH_REG_POINT0 0x0014
+
+static_assert(!DISPLAY_SWAP_XY, "ST77922 does not support swapping the X and Y axes");
 
 static i2c_master_dev_handle_t touch_dev_handle = NULL;
 static uint8_t touch_max_points = 1;
 
-static esp_err_t touch_i2c_read(uint16_t reg, uint8_t *data, size_t len) {
-    if (touch_dev_handle == NULL) return ESP_FAIL;
-    uint8_t wbuf[2] = { (uint8_t)(reg >> 8), (uint8_t)(reg & 0xFF) };
-    return i2c_master_transmit_receive(touch_dev_handle, wbuf, 2, data, len, pdMS_TO_TICKS(100));
+static esp_err_t touch_i2c_read(uint16_t reg, uint8_t* data, size_t len) {
+    if (touch_dev_handle == NULL)
+        return ESP_FAIL;
+    uint8_t wbuf[2] = {(uint8_t)(reg >> 8), (uint8_t)(reg & 0xFF)};
+    return i2c_master_transmit_receive(touch_dev_handle, wbuf, 2, data, len, 100);
 }
 
-static void touchpad_read(lv_indev_t *, lv_indev_data_t *data) {
+static void touchpad_read(lv_indev_t*, lv_indev_data_t* data) {
     static int16_t last_x = 0, last_y = 0;
     data->point.x = last_x;
     data->point.y = last_y;
     data->state = LV_INDEV_STATE_RELEASED;
 
-    if (touch_dev_handle == NULL) return;
+    if (touch_dev_handle == NULL)
+        return;
     uint8_t info;
-    if (touch_i2c_read(TOUCH_REG_INFO, &info, 1) != ESP_OK) return;
+    if (touch_i2c_read(TOUCH_REG_INFO, &info, 1) != ESP_OK)
+        return;
     if (info & 0x08) {
         uint8_t buf[7 * 5];
         if (touch_i2c_read(TOUCH_REG_POINT0, buf, 7 * touch_max_points) == ESP_OK) {
@@ -65,86 +70,108 @@ static void touchpad_read(lv_indev_t *, lv_indev_data_t *data) {
 
 // ---- ST77922 init commands ----
 static const st77922_lcd_init_cmd_t lcd_init_cmds[] = {
-    {0xF1, (uint8_t []){0x00}, 1, 0},
-    {0x60, (uint8_t []){0x00, 0x00, 0x00}, 3, 0},
-    {0x65, (uint8_t []){0x80}, 1, 0},
-    {0x79, (uint8_t []){0x06}, 1, 0},
-    {0x7B, (uint8_t []){0x00, 0x08, 0x08}, 3, 0},
-    {0x80, (uint8_t []){0x55, 0x62, 0x2F, 0x17, 0xF0, 0x52, 0x70, 0xD2, 0x52, 0x62, 0xEA}, 11, 0},
-    {0x81, (uint8_t []){0x26, 0x52, 0x72, 0x27}, 4, 0},
-    {0x84, (uint8_t []){0x92, 0x25}, 2, 0},
-    {0x87, (uint8_t []){0x10, 0x10, 0x58, 0x00, 0x02, 0x3A}, 6, 0},
-    {0x88, (uint8_t []){0x00, 0x00, 0x2C, 0x10, 0x04, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00, 0x06}, 15, 0},
-    {0x89, (uint8_t []){0x00, 0x00, 0x00}, 3, 0},
-    {0x8A, (uint8_t []){0x13, 0x00, 0x2C, 0x00, 0x00, 0x2C, 0x10, 0x10, 0x00, 0x3E, 0x19}, 11, 0},
-    {0x8B, (uint8_t []){0x15, 0xB1, 0xB1, 0x44, 0x96, 0x2C, 0x10, 0x97, 0x8E}, 9, 0},
-    {0x8C, (uint8_t []){0x1D, 0xB1, 0xB1, 0x44, 0x96, 0x2C, 0x10, 0x50, 0x0F, 0x01, 0xC5, 0x12, 0x09}, 13, 0},
-    {0x8D, (uint8_t []){0x0C}, 1, 0},
-    {0x8E, (uint8_t []){0x33, 0x01, 0x0C, 0x13, 0x01, 0x01}, 6, 0},
-    {0xB3, (uint8_t []){0x00, 0x30}, 2, 0},
-    {0xF1, (uint8_t []){0x00}, 1, 0},
-    {0x71, (uint8_t []){0xD0}, 1, 0},
-    {0x66, (uint8_t []){0x02, 0x3F}, 2, 0},
-    {0xBE, (uint8_t []){0x26, 0x00, 0x9D}, 3, 0},
-    {0x70, (uint8_t []){0x01, 0xA0, 0x11, 0x40, 0xE0, 0x00, 0x11, 0x69, 0x11, 0x00, 0x00, 0x1A}, 12, 0},
-    {0x90, (uint8_t []){0x04, 0x04, 0x55, 0x74, 0x00, 0x40, 0x43, 0x27, 0x27}, 9, 0},
-    {0x91, (uint8_t []){0x04, 0x04, 0x55, 0x75, 0x00, 0x40, 0x42, 0x27, 0x27}, 9, 0},
-    {0x92, (uint8_t []){0x04, 0x44, 0x55, 0xC0, 0x06, 0x00, 0x07, 0x05, 0x90, 0x27}, 10, 0},
-    {0x93, (uint8_t []){0x04, 0x43, 0x11, 0x00, 0x00, 0x00, 0x00, 0x05, 0x90, 0x27}, 10, 0},
-    {0x94, (uint8_t []){0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 6, 0},
-    {0x95, (uint8_t []){0x96, 0x16, 0x00, 0x00, 0xFF}, 5, 0},
-    {0x96, (uint8_t []){0x44, 0x53, 0x03, 0x12, 0x23, 0x24, 0x06, 0x05, 0x94, 0x27, 0x00, 0x44}, 12, 0},
-    {0x97, (uint8_t []){0x44, 0x53, 0x47, 0x56, 0x20, 0x20, 0x02, 0x01, 0x94, 0x27, 0x00, 0x44}, 12, 0},
-    {0xBA, (uint8_t []){0x55, 0x94, 0x2D, 0x94, 0x27}, 5, 0},
-    {0x9A, (uint8_t []){0x40, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00}, 7, 0},
-    {0x9B, (uint8_t []){0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00}, 7, 0},
-    {0x9C, (uint8_t []){0x5C, 0x12, 0x00, 0x00, 0x10, 0x12, 0x00, 0x00, 0x10, 0x02, 0x00, 0x00, 0x00}, 13, 0},
-    {0x9D, (uint8_t []){0x8A, 0x51, 0x00, 0x00, 0x00, 0x80, 0x1E, 0x01}, 8, 0},
-    {0x9E, (uint8_t []){0x51, 0x00, 0x00, 0x00, 0x80, 0x1E, 0x01}, 7, 0},
-    {0xB4, (uint8_t []){0x1D, 0x1C, 0x1E, 0x0B, 0x14, 0x02, 0x13, 0x09, 0x1E, 0x00, 0x1E, 0x10}, 12, 0},
-    {0xB5, (uint8_t []){0x1D, 0x1C, 0x1E, 0x0A, 0x15, 0x03, 0x11, 0x08, 0x1E, 0x01, 0x1E, 0x12}, 12, 0},
-    {0xB6, (uint8_t []){0x77, 0x77, 0x00, 0x0A, 0xFF, 0x0A, 0xFF}, 7, 0},
-    {0x86, (uint8_t []){0xCD, 0x04, 0xB1, 0x02, 0x58, 0x12, 0x58, 0x0C, 0x13, 0x01, 0xA5, 0x00, 0xA5, 0xA5}, 14, 0},
-    {0xB7, (uint8_t []){0x07, 0x0A, 0x0E, 0x06, 0x05, 0x03, 0x2B, 0x03, 0x03, 0x42, 0x07, 0x10, 0x10, 0x2E, 0x3F, 0x0D}, 16, 0},
-    {0xB8, (uint8_t []){0x07, 0x0A, 0x0D, 0x05, 0x05, 0x02, 0x2B, 0x02, 0x03, 0x42, 0x06, 0x10, 0x0F, 0x2E, 0x3F, 0x0D}, 16, 0},
-    {0xB9, (uint8_t []){0x23, 0x23}, 2, 0},
-    {0xBF, (uint8_t []){0x10, 0x14, 0x14, 0x0B, 0x0B, 0x0B}, 6, 0},
-    {0xF2, (uint8_t []){0x00}, 1, 0},
-    {0x73, (uint8_t []){0x04, 0xDA, 0x12, 0x54, 0x47}, 5, 0},
-    {0x77, (uint8_t []){0x6B, 0x5B, 0xFD, 0xC3, 0xC5}, 5, 0},
-    {0x7A, (uint8_t []){0x15, 0x27}, 2, 0},
-    {0x7B, (uint8_t []){0x04, 0x57}, 2, 0},
-    {0x7E, (uint8_t []){0x01, 0x0E}, 2, 0},
-    {0xBF, (uint8_t []){0x36}, 1, 0},
-    {0xE3, (uint8_t []){0x40, 0x40}, 2, 0},
-    {0xF0, (uint8_t []){0x00}, 1, 0},
-    {0xD0, (uint8_t []){0x00}, 1, 0},
-    {0x2A, (uint8_t []){0x00, 0x00, 0x01, 0x3F}, 4, 0},
-    {0x2B, (uint8_t []){0x00, 0x00, 0x01, 0xDF}, 4, 0},
-    {0x21, (uint8_t []){0x00}, 0, 0},
-    {0x11, (uint8_t []){0x00}, 0, 120},
-    {0x29, (uint8_t []){0x00}, 0, 0},
-    {0x2C, (uint8_t []){0x00}, 0, 0},
-    {0x3A, (uint8_t []){0x01}, 1, 0},
-    {0x36, (uint8_t []){0x00}, 1, 0},
-    {0x35, (uint8_t []){0x01}, 1, 20},
+    {0xF1, (uint8_t[]){0x00}, 1, 0},
+    {0x60, (uint8_t[]){0x00, 0x00, 0x00}, 3, 0},
+    {0x65, (uint8_t[]){0x80}, 1, 0},
+    {0x79, (uint8_t[]){0x06}, 1, 0},
+    {0x7B, (uint8_t[]){0x00, 0x08, 0x08}, 3, 0},
+    {0x80, (uint8_t[]){0x55, 0x62, 0x2F, 0x17, 0xF0, 0x52, 0x70, 0xD2, 0x52, 0x62, 0xEA}, 11, 0},
+    {0x81, (uint8_t[]){0x26, 0x52, 0x72, 0x27}, 4, 0},
+    {0x84, (uint8_t[]){0x92, 0x25}, 2, 0},
+    {0x87, (uint8_t[]){0x10, 0x10, 0x58, 0x00, 0x02, 0x3A}, 6, 0},
+    {0x88,
+     (uint8_t[]){0x00, 0x00, 0x2C, 0x10, 0x04, 0x00, 0x00, 0x00, 0x01, 0x01, 0x01, 0x01, 0x01, 0x00,
+                 0x06},
+     15, 0},
+    {0x89, (uint8_t[]){0x00, 0x00, 0x00}, 3, 0},
+    {0x8A, (uint8_t[]){0x13, 0x00, 0x2C, 0x00, 0x00, 0x2C, 0x10, 0x10, 0x00, 0x3E, 0x19}, 11, 0},
+    {0x8B, (uint8_t[]){0x15, 0xB1, 0xB1, 0x44, 0x96, 0x2C, 0x10, 0x97, 0x8E}, 9, 0},
+    {0x8C,
+     (uint8_t[]){0x1D, 0xB1, 0xB1, 0x44, 0x96, 0x2C, 0x10, 0x50, 0x0F, 0x01, 0xC5, 0x12, 0x09}, 13,
+     0},
+    {0x8D, (uint8_t[]){0x0C}, 1, 0},
+    {0x8E, (uint8_t[]){0x33, 0x01, 0x0C, 0x13, 0x01, 0x01}, 6, 0},
+    {0xB3, (uint8_t[]){0x00, 0x30}, 2, 0},
+    {0xF1, (uint8_t[]){0x00}, 1, 0},
+    {0x71, (uint8_t[]){0xD0}, 1, 0},
+    {0x66, (uint8_t[]){0x02, 0x3F}, 2, 0},
+    {0xBE, (uint8_t[]){0x26, 0x00, 0x9D}, 3, 0},
+    {0x70, (uint8_t[]){0x01, 0xA0, 0x11, 0x40, 0xE0, 0x00, 0x11, 0x69, 0x11, 0x00, 0x00, 0x1A}, 12,
+     0},
+    {0x90, (uint8_t[]){0x04, 0x04, 0x55, 0x74, 0x00, 0x40, 0x43, 0x27, 0x27}, 9, 0},
+    {0x91, (uint8_t[]){0x04, 0x04, 0x55, 0x75, 0x00, 0x40, 0x42, 0x27, 0x27}, 9, 0},
+    {0x92, (uint8_t[]){0x04, 0x44, 0x55, 0xC0, 0x06, 0x00, 0x07, 0x05, 0x90, 0x27}, 10, 0},
+    {0x93, (uint8_t[]){0x04, 0x43, 0x11, 0x00, 0x00, 0x00, 0x00, 0x05, 0x90, 0x27}, 10, 0},
+    {0x94, (uint8_t[]){0x00, 0x00, 0x00, 0x00, 0x00, 0x00}, 6, 0},
+    {0x95, (uint8_t[]){0x96, 0x16, 0x00, 0x00, 0xFF}, 5, 0},
+    {0x96, (uint8_t[]){0x44, 0x53, 0x03, 0x12, 0x23, 0x24, 0x06, 0x05, 0x94, 0x27, 0x00, 0x44}, 12,
+     0},
+    {0x97, (uint8_t[]){0x44, 0x53, 0x47, 0x56, 0x20, 0x20, 0x02, 0x01, 0x94, 0x27, 0x00, 0x44}, 12,
+     0},
+    {0xBA, (uint8_t[]){0x55, 0x94, 0x2D, 0x94, 0x27}, 5, 0},
+    {0x9A, (uint8_t[]){0x40, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00}, 7, 0},
+    {0x9B, (uint8_t[]){0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00}, 7, 0},
+    {0x9C,
+     (uint8_t[]){0x5C, 0x12, 0x00, 0x00, 0x10, 0x12, 0x00, 0x00, 0x10, 0x02, 0x00, 0x00, 0x00}, 13,
+     0},
+    {0x9D, (uint8_t[]){0x8A, 0x51, 0x00, 0x00, 0x00, 0x80, 0x1E, 0x01}, 8, 0},
+    {0x9E, (uint8_t[]){0x51, 0x00, 0x00, 0x00, 0x80, 0x1E, 0x01}, 7, 0},
+    {0xB4, (uint8_t[]){0x1D, 0x1C, 0x1E, 0x0B, 0x14, 0x02, 0x13, 0x09, 0x1E, 0x00, 0x1E, 0x10}, 12,
+     0},
+    {0xB5, (uint8_t[]){0x1D, 0x1C, 0x1E, 0x0A, 0x15, 0x03, 0x11, 0x08, 0x1E, 0x01, 0x1E, 0x12}, 12,
+     0},
+    {0xB6, (uint8_t[]){0x77, 0x77, 0x00, 0x0A, 0xFF, 0x0A, 0xFF}, 7, 0},
+    {0x86,
+     (uint8_t[]){0xCD, 0x04, 0xB1, 0x02, 0x58, 0x12, 0x58, 0x0C, 0x13, 0x01, 0xA5, 0x00, 0xA5,
+                 0xA5},
+     14, 0},
+    {0xB7,
+     (uint8_t[]){0x07, 0x0A, 0x0E, 0x06, 0x05, 0x03, 0x2B, 0x03, 0x03, 0x42, 0x07, 0x10, 0x10, 0x2E,
+                 0x3F, 0x0D},
+     16, 0},
+    {0xB8,
+     (uint8_t[]){0x07, 0x0A, 0x0D, 0x05, 0x05, 0x02, 0x2B, 0x02, 0x03, 0x42, 0x06, 0x10, 0x0F, 0x2E,
+                 0x3F, 0x0D},
+     16, 0},
+    {0xB9, (uint8_t[]){0x23, 0x23}, 2, 0},
+    {0xBF, (uint8_t[]){0x10, 0x14, 0x14, 0x0B, 0x0B, 0x0B}, 6, 0},
+    {0xF2, (uint8_t[]){0x00}, 1, 0},
+    {0x73, (uint8_t[]){0x04, 0xDA, 0x12, 0x54, 0x47}, 5, 0},
+    {0x77, (uint8_t[]){0x6B, 0x5B, 0xFD, 0xC3, 0xC5}, 5, 0},
+    {0x7A, (uint8_t[]){0x15, 0x27}, 2, 0},
+    {0x7B, (uint8_t[]){0x04, 0x57}, 2, 0},
+    {0x7E, (uint8_t[]){0x01, 0x0E}, 2, 0},
+    {0xBF, (uint8_t[]){0x36}, 1, 0},
+    {0xE3, (uint8_t[]){0x40, 0x40}, 2, 0},
+    {0xF0, (uint8_t[]){0x00}, 1, 0},
+    {0xD0, (uint8_t[]){0x00}, 1, 0},
+    {0x2A, (uint8_t[]){0x00, 0x00, 0x01, 0x3F}, 4, 0},
+    {0x2B, (uint8_t[]){0x00, 0x00, 0x01, 0xDF}, 4, 0},
+    {0x21, (uint8_t[]){0x00}, 0, 0},
+    {0x11, (uint8_t[]){0x00}, 0, 120},
+    {0x29, (uint8_t[]){0x00}, 0, 0},
+    {0x2C, (uint8_t[]){0x00}, 0, 0},
+    {0x3A, (uint8_t[]){0x01}, 1, 0},
+    {0x36, (uint8_t[]){0x00}, 1, 0},
+    {0x35, (uint8_t[]){0x01}, 1, 20},
 };
 
 // ---- Display class with ST77922 4-pixel alignment ----
-static void st77922_rounder_cb(lv_event_t *e)
-{
-    lv_area_t *area = (lv_area_t *)lv_event_get_param(e);
+static void st77922_rounder_cb(lv_event_t* e) {
+    lv_area_t* area = (lv_area_t*)lv_event_get_param(e);
     area->x1 = (area->x1 >> 2) << 2;
     area->x2 = ((area->x2 >> 2) << 2) + 3;
 }
 
 class ST77922_Display : public LcdDisplay {
 private:
-    void LvglInit() {
+    void LvglInit(bool mirror_x, bool mirror_y, bool swap_xy) {
         lv_init();
         lvgl_port_cfg_t port_cfg = ESP_LVGL_PORT_INIT_CONFIG();
         port_cfg.task_priority = 1;
+#if CONFIG_SOC_CPU_CORES_NUM > 1
         port_cfg.task_affinity = 1;
+#endif
         lvgl_port_init(&port_cfg);
 
         const lvgl_port_display_cfg_t display_cfg = {
@@ -157,33 +184,36 @@ private:
             .hres = static_cast<uint32_t>(DISPLAY_WIDTH),
             .vres = static_cast<uint32_t>(DISPLAY_HEIGHT),
             .monochrome = false,
-            .rotation = {
-                .swap_xy = false,
-                .mirror_x = false,
-                .mirror_y = false,
-            },
+            .rotation =
+                {
+                    .swap_xy = swap_xy,
+                    .mirror_x = mirror_x,
+                    .mirror_y = mirror_y,
+                },
             .color_format = LV_COLOR_FORMAT_RGB565,
-            .flags = {
-                .buff_dma = 1,
-                .buff_spiram = 0,
-                .sw_rotate = 0,
-                .swap_bytes = 1,
-                .full_refresh = 0,
-                .direct_mode = 0,
-            },
+            .flags =
+                {
+                    .buff_dma = 1,
+                    .buff_spiram = 0,
+                    .sw_rotate = 0,
+                    .swap_bytes = 1,
+                    .full_refresh = 0,
+                    .direct_mode = 0,
+                },
         };
         display_ = lvgl_port_add_disp(&display_cfg);
         if (display_ != nullptr) {
-            lv_display_add_event_cb(display_, st77922_rounder_cb, LV_EVENT_INVALIDATE_AREA, nullptr);
+            lv_display_add_event_cb(display_, st77922_rounder_cb, LV_EVENT_INVALIDATE_AREA,
+                                    nullptr);
         }
     }
 
 public:
-    ST77922_Display(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_handle_t panel,
-                  int width, int height, int offset_x, int offset_y,
-                  bool mirror_x, bool mirror_y, bool swap_xy)
+    ST77922_Display(esp_lcd_panel_io_handle_t panel_io, esp_lcd_panel_handle_t panel, int width,
+                    int height, int offset_x, int offset_y, bool mirror_x, bool mirror_y,
+                    bool swap_xy)
         : LcdDisplay(panel_io, panel, width, height) {
-        LvglInit();
+        LvglInit(mirror_x, mirror_y, swap_xy);
         if (offset_x != 0 || offset_y != 0) {
             lv_display_set_offset(display_, offset_x, offset_y);
         }
@@ -205,7 +235,7 @@ private:
             .glitch_ignore_cnt = 7,
             .intr_priority = 0,
             .trans_queue_depth = 0,
-            .flags = { .enable_internal_pullup = 1 },
+            .flags = {.enable_internal_pullup = 1},
         };
         ESP_ERROR_CHECK(i2c_new_master_bus(&i2c_bus_cfg, &i2c_bus_));
     }
@@ -227,30 +257,39 @@ private:
         esp_lcd_panel_handle_t panel = nullptr;
 
         ESP_LOGI(TAG, "Install QSPI panel IO");
-        esp_lcd_panel_io_spi_config_t io_config = ST77922_PANEL_IO_QSPI_CONFIG(DISPLAY_CS_PIN, NULL, NULL);
+        esp_lcd_panel_io_spi_config_t io_config = {};
+        io_config.cs_gpio_num = DISPLAY_CS_PIN;
+        io_config.dc_gpio_num = GPIO_NUM_NC;
+        io_config.spi_mode = 0;
         io_config.pclk_hz = 80 * 1000 * 1000;
+        io_config.trans_queue_depth = 10;
+        io_config.lcd_cmd_bits = 32;
+        io_config.lcd_param_bits = 8;
+        io_config.flags.quad_mode = true;
         ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi(SPI2_HOST, &io_config, &panel_io));
 
         ESP_LOGI(TAG, "Install ST77922 LCD driver");
         st77922_vendor_config_t vendor_config = {
             .init_cmds = lcd_init_cmds,
             .init_cmds_size = sizeof(lcd_init_cmds) / sizeof(st77922_lcd_init_cmd_t),
-            .flags = { .use_qspi_interface = 1 },
+            .flags = {.use_qspi_interface = 1},
         };
         esp_lcd_panel_dev_config_t panel_config = {};
         panel_config.reset_gpio_num = DISPLAY_RST_PIN;
         panel_config.rgb_ele_order = DISPLAY_RGB_ORDER;
         panel_config.bits_per_pixel = 16;
-        panel_config.vendor_config = (void *)&vendor_config;
+        panel_config.vendor_config = (void*)&vendor_config;
 
         ESP_ERROR_CHECK(esp_lcd_new_panel_st77922(panel_io, &panel_config, &panel));
         ESP_ERROR_CHECK(esp_lcd_panel_reset(panel));
         ESP_ERROR_CHECK(esp_lcd_panel_init(panel));
+        ESP_ERROR_CHECK(esp_lcd_panel_invert_color(panel, DISPLAY_INVERT_COLOR));
+        ESP_ERROR_CHECK(esp_lcd_panel_mirror(panel, DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y));
         ESP_ERROR_CHECK(esp_lcd_panel_disp_on_off(panel, true));
 
-        display_ = new ST77922_Display(panel_io, panel,
-            DISPLAY_WIDTH, DISPLAY_HEIGHT, DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y,
-            DISPLAY_MIRROR_X, DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
+        display_ = new ST77922_Display(panel_io, panel, DISPLAY_WIDTH, DISPLAY_HEIGHT,
+                                       DISPLAY_OFFSET_X, DISPLAY_OFFSET_Y, DISPLAY_MIRROR_X,
+                                       DISPLAY_MIRROR_Y, DISPLAY_SWAP_XY);
     }
 
     void InitializeTouch() {
@@ -261,7 +300,7 @@ private:
         };
         ESP_ERROR_CHECK(i2c_master_bus_add_device(i2c_bus_, &dev_cfg, &touch_dev_handle));
 
-        gpio_config_t rst_cfg = { .pin_bit_mask = (1ULL << TOUCH_RST_PIN), .mode = GPIO_MODE_OUTPUT };
+        gpio_config_t rst_cfg = {.pin_bit_mask = (1ULL << TOUCH_RST_PIN), .mode = GPIO_MODE_OUTPUT};
         gpio_config(&rst_cfg);
         gpio_set_level(TOUCH_RST_PIN, 0);
         vTaskDelay(pdMS_TO_TICKS(10));
@@ -270,12 +309,13 @@ private:
 
         // Read max supported touch points
         uint8_t max_pts;
-        if (touch_i2c_read(TOUCH_REG_MAX_TOUCHES, &max_pts, 1) == ESP_OK && max_pts > 0 && max_pts <= 5) {
+        if (touch_i2c_read(TOUCH_REG_MAX_TOUCHES, &max_pts, 1) == ESP_OK && max_pts > 0 &&
+            max_pts <= 5) {
             touch_max_points = max_pts;
         }
         ESP_LOGI(TAG, "Touch max points: %d", touch_max_points);
 
-        lv_indev_t *indev = lv_indev_create();
+        lv_indev_t* indev = lv_indev_create();
         lv_indev_set_type(indev, LV_INDEV_TYPE_POINTER);
         lv_indev_set_read_cb(indev, touchpad_read);
         lv_indev_set_disp(indev, lv_display_get_default());
@@ -294,14 +334,14 @@ private:
     }
 
     void InitializeTools() {
-        auto &mcp_server = McpServer::GetInstance();
+        auto& mcp_server = McpServer::GetInstance();
         mcp_server.AddTool("self.system.reconfigure_wifi",
-            "End this conversation and enter WiFi configuration mode.\n"
-            "**CAUTION** You must ask the user to confirm this action.",
-            PropertyList(), [this](const PropertyList& properties) {
-                EnterWifiConfigMode();
-                return true;
-            });
+                           "End this conversation and enter WiFi configuration mode.\n"
+                           "**CAUTION** You must ask the user to confirm this action.",
+                           PropertyList(), [this](const PropertyList& properties) {
+                               EnterWifiConfigMode();
+                               return true;
+                           });
     }
 
 public:
@@ -316,11 +356,10 @@ public:
     }
 
     virtual AudioCodec* GetAudioCodec() override {
-        static Es8311AudioCodec audio_codec(i2c_bus_, I2C_NUM_0,
-            AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,
-            AUDIO_I2S_GPIO_MCLK, AUDIO_I2S_GPIO_BCLK, AUDIO_I2S_GPIO_WS,
-            AUDIO_I2S_GPIO_DOUT, AUDIO_I2S_GPIO_DIN,
-            AUDIO_CODEC_PA_PIN, AUDIO_CODEC_ES8311_ADDR, true, true);
+        static Es8311AudioCodec audio_codec(
+            i2c_bus_, I2C_NUM_0, AUDIO_INPUT_SAMPLE_RATE, AUDIO_OUTPUT_SAMPLE_RATE,
+            AUDIO_I2S_GPIO_MCLK, AUDIO_I2S_GPIO_BCLK, AUDIO_I2S_GPIO_WS, AUDIO_I2S_GPIO_DOUT,
+            AUDIO_I2S_GPIO_DIN, AUDIO_CODEC_PA_PIN, AUDIO_CODEC_ES8311_ADDR, true, true);
         return &audio_codec;
     }
 

--- a/main/boards/m5stack-tab5/README.md
+++ b/main/boards/m5stack-tab5/README.md
@@ -8,16 +8,17 @@
 
 ## 基础使用
 
-* idf version: v5.5.2 or above (recommended: v6.0-dev)
+* idf version: v5.5.2 or above (recommended: v6.0.2)
 
 * No dependency override needed — the project already specifies the correct `esp_video` and `esp_ipa` versions in `main/idf_component.yml`. Do NOT change the dependency versions unless you are also modifying the source code to match the older API.
 
 `release.py` 会根据当前 ESP-IDF 版本选择芯片版本：
 
-- ESP-IDF < 6：`m5stack-tab5` 面向 Rev < 3，并包含 `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` 和 `CONFIG_ESP32P4_REV_MIN_100=y`；`m5stack-tab5-p4x` 面向 Rev >= 3。
-- ESP-IDF >= 6：只提供面向 Rev >= 3 的 `m5stack-tab5-p4x`。
+- `m5stack-tab5` 面向 Rev < 3，并包含 `CONFIG_ESP32P4_SELECTS_REV_LESS_V3=y` 和 `CONFIG_ESP32P4_REV_MIN_100=y`。
+- `m5stack-tab5-p4x` 面向 Rev >= 3。
+- ESP-IDF 6 构建需要 `esp-sr` 2.4.7 或更高版本，两个芯片修订版均可用。
 
-不要把 IDF 6 生成的固件强制刷入 Rev 1.x 芯片；正常情况下烧录工具会报告：`bootloader/bootloader.bin requires chip revision in range [v3.0 - v3.99] (this chip is revision v1.x)`。
+不要把 `m5stack-tab5-p4x` 固件强制刷入 Rev 1.x 芯片；应改用无后缀的 `m5stack-tab5` 固件。误用 P4X 固件时，正常情况下烧录工具会报告：`bootloader/bootloader.bin requires chip revision in range [v3.0 - v3.99] (this chip is revision v1.x)`。
 
 1. 使用 release.py 编译
 

--- a/main/boards/m5stack-tab5/config.json
+++ b/main/boards/m5stack-tab5/config.json
@@ -3,7 +3,6 @@
     "builds": [
         {
             "name": "m5stack-tab5",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_BOARD_TYPE_M5STACK_CORE_TAB5=y",
                 "CONFIG_CAMERA_SC202CS=y",

--- a/main/boards/waveshare/esp32-p4-nano/config.json
+++ b/main/boards/waveshare/esp32-p4-nano/config.json
@@ -4,7 +4,6 @@
     "builds": [
         {
             "name": "esp32-p4-nano-10.1-a",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=y",
                 "CONFIG_CAMERA_OV5647=y",

--- a/main/boards/waveshare/esp32-p4-wifi6-touch-lcd-3.5/config.json
+++ b/main/boards/waveshare/esp32-p4-wifi6-touch-lcd-3.5/config.json
@@ -4,7 +4,6 @@
     "builds": [
         {
             "name": "esp32-p4-wifi6-touch-lcd-3.5",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",

--- a/main/boards/waveshare/esp32-p4-wifi6-touch-lcd/config.json
+++ b/main/boards/waveshare/esp32-p4-wifi6-touch-lcd/config.json
@@ -4,7 +4,6 @@
     "builds": [
         {
             "name": "esp32-p4-wifi6-touch-lcd-4b",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -35,7 +34,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-4.3",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -66,7 +64,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-5",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -97,7 +94,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-7b",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -134,7 +130,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-3.4c",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -165,7 +160,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-4c",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -196,7 +190,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-7",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -227,7 +220,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-8",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",
@@ -258,7 +250,6 @@
         },
         {
             "name": "esp32-p4-wifi6-touch-lcd-10.1",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_SPIRAM_MALLOC_ALWAYSINTERNAL=0",
                 "CONFIG_BOOTLOADER_CACHE_32BIT_ADDR_QUAD_FLASH=y",

--- a/main/boards/wireless-tag-wtp4c5mp07s/config.json
+++ b/main/boards/wireless-tag-wtp4c5mp07s/config.json
@@ -3,7 +3,6 @@
     "builds": [
         {
             "name": "wireless-tag-wtp4c5mp07s",
-            "idf_version": "<6.0",
             "sdkconfig_append": [
                 "CONFIG_USE_WECHAT_MESSAGE_STYLE=n",
                 "CONFIG_SLAVE_IDF_TARGET_ESP32C5=y",

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -33,7 +33,7 @@ dependencies:
   78/xiaozhi-fonts: ~2.0.0
   espressif/led_strip: ~3.0.2
   espressif/esp_codec_dev: ~1.5.6
-  espressif/esp-sr: ~2.4.6
+  espressif/esp-sr: ~2.4.7
   espressif/button: ~4.2.0
   espressif/knob: ^1.0.0
   esphome/esp-hub75:

--- a/scripts/tests/test_release.py
+++ b/scripts/tests/test_release.py
@@ -21,14 +21,16 @@ class VersionTests(unittest.TestCase):
         with self.assertRaises(ValueError):
             release._version_matches((6, 0, 1), "~=6.0")
 
-    def test_current_matrix_counts_and_uniqueness(self):
+    def test_current_matrix_uniqueness_and_p4_variants(self):
         idf5 = release._collect_variants(idf_version=(5, 5, 4))
         idf6 = release._collect_variants(idf_version=(6, 0, 1))
-        self.assertEqual(len(idf5), 172)
-        self.assertEqual(len(idf6), 158)
         for variants in (idf5, idf6):
             names = [variant["full_name"] for variant in variants]
             self.assertEqual(len(names), len(set(names)))
+
+        idf6_names = {variant["full_name"] for variant in idf6}
+        self.assertIn("esp-p4-function-ev-board", idf6_names)
+        self.assertIn("esp-p4-function-ev-board-p4x", idf6_names)
 
 
 class BoardSelectionTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Update `esp-sr` from 2.4.5 to 2.4.7.
- Allow ESP32-P4 Rev1 variants to build under ESP-IDF 6 while preserving `p4x` Rev3 variants.
- Remove the fixed build-matrix count assertion so new development boards can be added without updating a hardcoded total.
- Fix the LCDWiki ES3C35P ESP-IDF 6 build and address the latest review feedback from #2112.

## LCDWiki root cause and fixes

The ST77922 QSPI helper macro initializes `dc_gpio_num` with integer `-1`, which fails the stricter C++ enum conversion in ESP-IDF 6. The board now uses an explicit panel IO configuration with `GPIO_NUM_NC`.

The patch also corrects the touch I2C timeout unit, only applies task affinity on multicore targets, uses the requested LVGL rotation, applies panel inversion/mirroring settings, and rejects the unsupported swap-XY configuration at compile time.

## Validation

- `python3 -m unittest discover -s scripts/tests -v` — 8 tests passed
- `clang-format --dry-run -Werror main/boards/lcdwiki-es3c35p/lcdwiki-es3c35p.cc`
- `git diff --check origin/main...HEAD`
- `python3 scripts/release.py lcdwiki-es3c35p --name lcdwiki-es3c35p` with ESP-IDF 6.0.1 — build and release ZIP succeeded; application partition has 31% free

Physical LCD/touch behavior still requires validation on the LCDWiki ES3C35P hardware.