### PR TITLE
feat(boards): double-click BOOT to enter WiFi config mode

### DIFF
--- a/main/boards/bread-compact-wifi-s3cam/compact_wifi_board_s3cam.cc
+++ b/main/boards/bread-compact-wifi-s3cam/compact_wifi_board_s3cam.cc
@@ -162,6 +162,8 @@ private:
             }
             app.ToggleChatState();
         });
+        // Double-click BOOT to enter WiFi config mode (reconfigure WiFi/API keys)
+        SetupDoubleClickForConfigMode(boot_button_);
     }
 
 public:

--- a/main/boards/common/wifi_board.cc
+++ b/main/boards/common/wifi_board.cc
@@ -1,6 +1,7 @@
 #include "wifi_board.h"
 
 #include "display.h"
+#include "button.h"
 #include "application.h"
 #include "system_info.h"
 #include "settings.h"
@@ -351,4 +352,17 @@ std::string WifiBoard::GetDeviceStatusJson() {
     cJSON_free(str);
     cJSON_Delete(root);
     return result;
+}
+
+void WifiBoard::SetupDoubleClickForConfigMode(Button& button) {
+    button.OnDoubleClick([this]() {
+        auto& app = Application::GetInstance();
+        auto state = app.GetDeviceState();
+        // Only enter config mode when device is running (not during startup,
+        // since startup already uses single-click for config mode)
+        if (state == kDeviceStateIdle || state == kDeviceStateListening ||
+            state == kDeviceStateSpeaking) {
+            EnterWifiConfigMode();
+        }
+    });
 }

--- a/main/boards/common/wifi_board.h
+++ b/main/boards/common/wifi_board.h
@@ -64,6 +64,14 @@ public:
      * Check if in WiFi config mode
      */
     bool IsInWifiConfigMode() const;
+
+    /**
+     * Register double-click on a button to enter WiFi config mode.
+     * Call this from InitializeButtons() after setting up single-click.
+     * The double-click handler is active only when device is NOT in starting state
+     * (since starting state already uses single-click for config mode).
+     */
+    void SetupDoubleClickForConfigMode(Button& button);
 };
 
 #endif // WIFI_BOARD_H

--- a/main/boards/lceda-course-examples/eda-tv-pro/eda-tv-pro.cc
+++ b/main/boards/lceda-course-examples/eda-tv-pro/eda-tv-pro.cc
@@ -76,6 +76,8 @@ private:
             }
             app.ToggleChatState();
         });
+        // Double-click BOOT to enter WiFi config mode (reconfigure WiFi/API keys)
+        SetupDoubleClickForConfigMode(boot_button_);
     }
 
 public:

--- a/main/boards/xmini/c3-v3/xmini_c3_board.cc
+++ b/main/boards/xmini/c3-v3/xmini_c3_board.cc
@@ -150,6 +150,8 @@ private:
                 Application::GetInstance().StopListening();
             }
         });
+        // Double-click BOOT to enter WiFi config mode (reconfigure WiFi/API keys)
+        SetupDoubleClickForConfigMode(boot_button_);
     }
 
     void InitializeTools() {


### PR DESCRIPTION
## What

Double-click the BOOT button while the device is running to enter WiFi configuration mode (captive portal). This lets users reconfigure WiFi credentials, API keys (Tavily), OTA URL, and other settings **without rebooting**.

## Why

Currently, the config portal is only accessible:
- At first boot (no WiFi configured)
- After WiFi connection timeout (60s)
- During startup state (single-click BOOT)

There is no way to reconfigure settings while the device is actively running. Users who need to change WiFi networks (e.g., switching between home and mobile hotspot) or update API keys must wait for timeout or reboot.

Addresses #2103 (WiFi config save and auto-connect)

## How

- Added `SetupDoubleClickForConfigMode(Button&)` helper in `WifiBoard` base class
- Board files call this one-liner in `InitializeButtons()` after existing single-click setup
- Double-click triggers `EnterWifiConfigMode()` only when device is idle/listening/speaking (not during startup, since startup already uses single-click)
- Uses existing `iot_button` `OnDoubleClick` infrastructure — no new dependencies
- Config portal already has WiFi + Advanced (OTA, TX power, BSSID, sleep, Tavily API key) tabs

## Boards Modified

- `xmini/c3-v3` — ESP32-C3 reference board
- `lceda-course-examples/eda-tv-pro` — EDA education board
- `bread-compact-wifi-s3cam` — WiFi + camera board

Other boards can adopt by adding one line:
```cpp
SetupDoubleClickForConfigMode(boot_button_);
```

## Testing

1. Build for any modified board
2. Boot device, wait for WiFi connection
3. Double-click BOOT button → device enters config mode (AP + web portal)
4. Open browser to the shown URL → WiFi + Advanced tabs available
5. Single-click BOOT still works normally (toggle chat)
6. Single-click during startup still enters config mode

## What NOT changed

- No changes to `managed_components/` (upstream component)
- No changes to sdkconfig or partition tables
- No new dependencies
- Single-click behavior completely unchanged
- Config portal UI unchanged (already has all needed features)