### PR TITLE
fix(lichuang-dev): don't crash when the FT5x06 touch controller is absent

### DIFF
--- a/main/boards/lckfb/szpi-esp32s3/lichuang_dev_board.cc
+++ b/main/boards/lckfb/szpi-esp32s3/lichuang_dev_board.cc
@@ -177,7 +177,7 @@ private:
 
     void InitializeTouch()
     {
-        esp_lcd_touch_handle_t tp;
+        esp_lcd_touch_handle_t tp = nullptr;
         esp_lcd_touch_config_t tp_cfg = {
             .x_max = DISPLAY_HEIGHT,
             .y_max = DISPLAY_WIDTH,
@@ -206,9 +206,15 @@ private:
         };
         tp_io_config.scl_speed_hz = 400000;
 
-        esp_lcd_new_panel_io_i2c(i2c_bus_, &tp_io_config, &tp_io_handle);
-        esp_lcd_touch_new_i2c_ft5x06(tp_io_handle, &tp_cfg, &tp);
-        assert(tp);
+        if (esp_lcd_new_panel_io_i2c(i2c_bus_, &tp_io_config, &tp_io_handle) != ESP_OK) {
+            ESP_LOGW(TAG, "Failed to create touch panel IO, continuing without touch");
+            return;
+        }
+        if (esp_lcd_touch_new_i2c_ft5x06(tp_io_handle, &tp_cfg, &tp) != ESP_OK || tp == nullptr) {
+            ESP_LOGW(TAG, "FT5x06 touch controller not found, continuing without touch");
+            esp_lcd_panel_io_del(tp_io_handle);
+            return;
+        }
 
         /* Add touch input (for selected screen) */
         const lvgl_port_touch_cfg_t touch_cfg = {


### PR DESCRIPTION
### Problem

`LichuangDevBoard::InitializeTouch()` declares its touch handle uninitialised, ignores the return value of both init calls, and then asserts on the handle:

```c
esp_lcd_touch_handle_t tp;
esp_lcd_new_panel_io_i2c(i2c_bus_, &tp_io_config, &tp_io_handle);
esp_lcd_touch_new_i2c_ft5x06(tp_io_handle, &tp_cfg, &tp);
assert(tp);
```

When the controller doesn't respond, `esp_lcd_touch_new_i2c_ft5x06()` leaves `tp` untouched, so `assert(tp)` tests whatever happened to be on the stack. A non-zero stack value passes the assert, and `lvgl_port_add_touch()` then dereferences it:

```
E FT5x06: esp_lcd_touch_new_i2c_ft5x06(161): FT5x06 init failed
E FT5x06: Error (0x108)! Touch controller FT5x06 initialization failed!
Guru Meditation Error: Core 0 panic'ed (LoadProhibited). Exception was unhandled.

Backtrace decoded:
  lvgl_port_add_touch at esp_lvgl_port_touch.c:57
  LichuangDevBoard::InitializeTouch() at lichuang_dev_board.cc:221
  LichuangDevBoard::LichuangDevBoard() at lichuang_dev_board.cc:282
  create_board() -> Board::GetInstance() -> Application::Initialize()
```

It happens during board construction, so the device never reaches `app_main()`'s event loop — it boot-loops indefinitely.

### Cause

The failure is silent by construction: the return value is discarded, and `assert()` on an uninitialised local is not a real check. It only surfaces on units where the controller is missing or faulty.

I hit this on a board with no touch panel fitted. An I2C scan finds only:

| Address | Device |
| --- | --- |
| `0x18` | ES8311 codec |
| `0x19` | PCA9557 IO expander |
| `0x41` | ES7210 ADC |

No `0x38`, so the FT5x06 is genuinely not present.

### Fix

Initialise the handle, check both return values, and treat a missing controller as "no touch". Touch is optional on this board — display, audio and buttons are unaffected — so skipping it is preferable to a boot loop. The `esp_lcd_panel_io_del()` call avoids leaking the panel IO handle when the touch probe fails.

Boards that do have a working FT5x06 take exactly the same path as before.

### Testing

- Builds clean: `scripts/build.py lckfb/szpi-esp32s3 --name lichuang-dev`
- Verified on hardware without a touch panel: previously boot-looped on every start, now logs a warning and boots through to idle, connects, and holds a conversation.

### Note

`rymcu/bigsmart` has the same uninitialised-handle pattern, but it wraps the calls in `ESP_ERROR_CHECK`, so a failure aborts with a diagnosable error rather than dereferencing garbage. I've left it alone since I have no such board to test on — happy to include it if you'd prefer consistency.