### PR TITLE
fix(df-k10): clamp self.led_strip.scroll length to the actual LED count

### DIFF
--- a/main/boards/dfrobot/df-k10/led_control.cc
+++ b/main/boards/dfrobot/df-k10/led_control.cc
@@ -105,7 +105,7 @@ LedStripControl::LedStripControl(CircularStrip* led_strip)
             Property("red", kPropertyTypeInteger, 0, 255),
             Property("green", kPropertyTypeInteger, 0, 255),
             Property("blue", kPropertyTypeInteger, 0, 255),
-            Property("length", kPropertyTypeInteger, 1, 7),
+            Property("length", kPropertyTypeInteger, 1, 3),
             Property("interval", kPropertyTypeInteger, 0, 1000)
         }), [this](const PropertyList& properties) -> ReturnValue {
             int red = properties["red"].value<int>();


### PR DESCRIPTION
## Summary
- The DFRobot K10's LED ring only has 3 LEDs (`new CircularStrip(BUILTIN_LED_GPIO, 3)` in `Df_K10Board::InitializeIot()`), but the `self.led_strip.scroll` MCP tool's `length` parameter accepted values up to 7.
- A scroll segment longer than the ring itself doesn't mean anything and just wraps oddly (`CircularStrip::Scroll` indexes with `% max_leds_`).
- Clamps the range to 1-3 to match the hardware.

Board-local, one-line change — no other board is affected (each board with a similar LED-strip tool set keeps its own independent copy of this file).

## Test plan
- [x] Built and flashed for `dfrobot/df-k10`; `self.led_strip.scroll` behaves as before for valid lengths, and the schema now rejects out-of-range values that never made sense for this board.