### PR TITLE
fix(display): redraw idle clock on minute change, not a shared timestamp

### DIFF
--- a/main/display/lvgl_display/lvgl_display.cc
+++ b/main/display/lvgl_display/lvgl_display.cc
@@ -210,22 +210,25 @@ void LvglDisplay::UpdateStatusBar(bool update_all) {
         }
     }
 
-    // Update time
+    // Update time — show HH:MM when idle; refresh immediately on state
+    // transitions (update_all=true) and on every minute change thereafter.
     if (app.GetDeviceState() == kDeviceStateIdle) {
-        if (last_status_update_time_ + std::chrono::seconds(10) <
-            std::chrono::system_clock::now()) {
-            // Set status to clock "HH:MM"
-            time_t now = time(NULL);
-            struct tm* tm = localtime(&now);
-            // Check if the we have already set the time
-            if (tm->tm_year >= 2025 - 1900) {
+        time_t now = time(NULL);
+        struct tm* tm_now = localtime(&now);
+        if (tm_now->tm_year >= 2025 - 1900) {
+            int cur_min = tm_now->tm_hour * 60 + tm_now->tm_min;
+            if (update_all || cur_min != last_displayed_clock_min_) {
+                last_displayed_clock_min_ = cur_min;
                 char time_str[16];
-                strftime(time_str, sizeof(time_str), "%H:%M", tm);
+                strftime(time_str, sizeof(time_str), "%H:%M", tm_now);
                 SetStatus(time_str);
-            } else {
-                ESP_LOGW(TAG, "System time is not set, tm_year: %d", tm->tm_year);
             }
+        } else {
+            ESP_LOGW(TAG, "System time not set (tm_year=%d)", tm_now->tm_year);
         }
+    } else {
+        // Reset so the clock re-appears immediately when idle resumes.
+        last_displayed_clock_min_ = -1;
     }
 
     esp_pm_lock_acquire(pm_lock_);

--- a/main/display/lvgl_display/lvgl_display.h
+++ b/main/display/lvgl_display/lvgl_display.h
@@ -50,6 +50,7 @@ protected:
 
     std::chrono::system_clock::time_point last_status_update_time_;
     esp_timer_handle_t notification_timer_ = nullptr;
+    int last_displayed_clock_min_ = -1;   // -1 forces update on first idle tick
     std::unique_ptr<DynamicGlyphCache> dynamic_glyph_cache_;
 
     friend class DisplayLockGuard;


### PR DESCRIPTION
## Summary
- `LvglDisplay::UpdateStatusBar()`'s idle clock only redrew when `last_status_update_time_ + 10s < now`.
- That timestamp isn't clock-specific — `SetStatus()` stamps it on *every* call, for any status text (`Connecting`, `Listening`, `Standby`, ...), not just the clock. So the actual rule enforced was "redraw the clock if nothing else has touched the status bar in the last 10 seconds," not "the displayed time is stale."
- `Application`'s own `clock_timer_handle_` already ticks `UpdateStatusBar()` every second (`esp_timer_start_periodic(clock_timer_handle_, 1000000)`), so if anything else calls `SetStatus()` reasonably often (under 10s apart), the 10-second window keeps getting reset before it can complete — the clock can go stale indefinitely, not just briefly.
- Tracks the actually-displayed minute (`last_displayed_clock_min_`) instead, and redraws exactly when it differs from the current minute, or when a caller passes `update_all=true` (previously ignored by this code path entirely, even though callers do pass it to request a forced refresh). Resets it to `-1` whenever the device leaves idle, so the clock is guaranteed to redraw the moment idle resumes rather than possibly appearing to skip an update from a stale leftover value.

No changes to the throttle for anything else in `UpdateStatusBar()` (battery/network/mute icons) — only the clock block.

## Test plan
- [x] Built and flashed for `dfrobot/df-k10`; idle clock updates correctly on minute boundaries and immediately on state transitions.
- [ ] Have not specifically reproduced the starvation case (some other frequent `SetStatus()` caller keeping the clock frozen) on real hardware, but the fix removes the shared-timestamp dependency that causes it by construction.