### PR TITLE
Fix camera format negotiation for big-endian RGB565 sensors (RGB565X)

### DIFF
--- a/main/boards/common/esp_video.cc
+++ b/main/boards/common/esp_video.cc
@@ -211,6 +211,7 @@ EspVideo::EspVideo(const esp_video_init_config_t& config) {
             case V4L2_PIX_FMT_RGB24:
                 return 0;
             case V4L2_PIX_FMT_RGB565:
+            case V4L2_PIX_FMT_RGB565X:  // byte-swapped to RGB565 in Capture()
                 return 1;
 #ifdef CONFIG_XIAOZHI_ENABLE_HARDWARE_JPEG_ENCODER
             case V4L2_PIX_FMT_YUV420:  // 软件 JPEG 编码器不支持 YUV420 格式
@@ -233,6 +234,7 @@ EspVideo::EspVideo(const esp_video_init_config_t& config) {
             case V4L2_PIX_FMT_YUV422P:
                 return 10;
             case V4L2_PIX_FMT_RGB565:
+            case V4L2_PIX_FMT_RGB565X:  // byte-swapped to RGB565 in Capture()
                 return 11;
             case V4L2_PIX_FMT_RGB24:
                 return 12;
@@ -414,6 +416,8 @@ bool EspVideo::Capture() {
     }
 
     if (!streaming_on_ || video_fd_ < 0) {
+        ESP_LOGE(TAG, "Capture failed: camera did not initialize (streaming_on_=%d, video_fd_=%d)", streaming_on_,
+                 video_fd_);
         return false;
     }
 


### PR DESCRIPTION
## Summary
- Sensors that only output big-endian RGB565 (e.g. GC2145 on the DFRobot 行空板 K10) are correctly reported by the current esp_video driver as the distinct `V4L2_PIX_FMT_RGB565X` fourcc, but `get_rank()` in `esp_video.cc` had no case for it, so format negotiation failed outright with `no supported pixel format found` — `self.camera.take_photo` always failed on these boards.
- `Capture()` already has a dedicated, correct byte-swap case for `V4L2_PIX_FMT_RGB565X` (there's even a comment noting it was added for exactly this "future esp_video version" scenario) — it just never got selected because `get_rank()` ranked it as unsupported.
- Adds `V4L2_PIX_FMT_RGB565X` alongside `V4L2_PIX_FMT_RGB565` in both `get_rank()` tables (rotate/PPA path and the default path), ranked identically to plain RGB565.
- Also logs the previously-silent early return in `Capture()` when the camera never initialized (`streaming_on_`/`video_fd_` not ready), since debugging this failure mode currently requires scrolling back to a possibly long-gone boot-time error.

## Test plan
- [x] Reproduced on real DFRobot 行空板 K10 hardware (GC2145 DVP sensor): `self.camera.take_photo` failed with `no supported pixel format found` before this change.
- [x] Confirmed fixed after the change: camera initializes, `take_photo` captures and uploads successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)