### PR TITLE
fix(esp32-s3-rlcd-4.2): 显存改用内部 DMA 内存，避免刷屏时临时分配失败导致 abort

### DIFF
--- a/main/boards/waveshare/esp32-s3-rlcd-4.2/custom_lcd_display.cc
+++ b/main/boards/waveshare/esp32-s3-rlcd-4.2/custom_lcd_display.cc
@@ -80,7 +80,14 @@ height_(height)
     Set_ResetIOLevel(1);
 
     DisplayLen                = transfer >> 3; //(1byte 8ipex)
-    DispBuffer                = (uint8_t *) heap_caps_malloc(DisplayLen, MALLOC_CAP_SPIRAM);
+    // 显存必须放在 DMA 可访问的内部内存：若放在 PSRAM，spi_master 每次
+    // tx_color 都要临时申请一块等大的内部 DMA 缓冲并 memcpy（见 setup_dma_priv_buffer），
+    // 对话时刷屏频繁，该临时分配会在内存紧张时失败。
+    DispBuffer                = (uint8_t *) heap_caps_malloc(DisplayLen, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
+    if (DispBuffer == nullptr) {
+        ESP_LOGW(TAG, "内部 DMA 显存分配失败(%d 字节)，回退到 PSRAM", (int)DisplayLen);
+        DispBuffer            = (uint8_t *) heap_caps_malloc(DisplayLen, MALLOC_CAP_SPIRAM);
+    }
     assert(DispBuffer);
 	PixelIndexLUT = (uint16_t (*)[300])heap_caps_malloc(transfer * sizeof(uint16_t), MALLOC_CAP_SPIRAM);
 	PixelBitLUT   = (uint8_t (*)[300])heap_caps_malloc(transfer * sizeof(uint8_t), MALLOC_CAP_SPIRAM);
@@ -178,7 +185,12 @@ void CustomLcdDisplay::RLCD_SendData(uint8_t Data) {
 }
 
 void CustomLcdDisplay::RLCD_Sendbuffera(uint8_t *Data, int len) {
-    ESP_ERROR_CHECK(esp_lcd_panel_io_tx_color(io_handle, -1, Data, len));
+    // 不用 ESP_ERROR_CHECK：DMA 缓冲分配失败是可恢复的瞬时状态，
+    // 丢一帧画面远好过 abort() 重启整机。
+    esp_err_t err = esp_lcd_panel_io_tx_color(io_handle, -1, Data, len);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "刷屏失败，跳过本帧: %s", esp_err_to_name(err));
+    }
 }
 
 void CustomLcdDisplay::RLCD_Reset(void) {


### PR DESCRIPTION
The RLCD 4.2 framebuffer lives in PSRAM, which SPI cannot DMA from directly.
Every refresh makes `spi_master` allocate a 15 KB temporary internal DMA buffer; under memory pressure that allocation fails and `ESP_ERROR_CHECK` aborts the whole device.
This moves the framebuffer into internal DMA-capable memory and downgrades a transient refresh failure from `abort()` to a dropped frame.

---

## 问题现象

板子：Waveshare ESP32-S3-RLCD-4.2（`main/boards/waveshare/esp32-s3-rlcd-4.2/`，400x300 1-bit 反射屏）。

语音对话时，AI 流式输出文本会让屏幕高频刷新。对话进行到一定时长后设备会**随机 abort 并整机重启**，且越是长对话越容易触发。崩溃点固定在 `custom_lcd_display.cc` 的 `RLCD_Sendbuffera`：

```
I (154114) Application: << 这个时间是从网络时间服务器获取的实时数据，
E (154574) spi_master: setup_dma_priv_buffer(1214): Failed to allocate priv TX buffer
E (154574) lcd_panel.io.spi: panel_io_spi_tx_color(405): spi transmit (queue) color failed
ESP_ERROR_CHECK failed: esp_err_t 0x101 (ESP_ERR_NO_MEM) at 0x42020e83
file: "./main/boards/waveshare/esp32-s3-rlcd-4.2/custom_lcd_display.cc" line 181
func: void CustomLcdDisplay::RLCD_Sendbuffera(uint8_t*, int)
expression: esp_lcd_panel_io_tx_color(io_handle, -1, Data, len)

abort() was called at PC 0x403856c7 on core 0

Backtrace: 0x40385709:0x3fcee160 0x403856d1:0x3fcee180 0x4038d096:0x3fcee1a0 0x403856c7:0x3fcee210 0x42020e83:0x3fcee240 0x4202148f:0x3fcee260 0x420214c3:0x3fcee280 0x420bc5e8:0x3fcee2a0 0x420bd79d:0x3fcee2d0 0x420c8816:0x3fcee360 0x420b2858:0x3fcee390

Rebooting...
```

崩溃前几秒的内存水位已经很低（同一份日志里 `SystemInfo: free sram: 16687 minimal sram: 1816`），这与失败原因一致。

## 根因分析

显存 `DispBuffer` 原来是从 PSRAM 分配的：

```cpp
DisplayLen = transfer >> 3;                 // 400 * 300 / 8 = 15000
DispBuffer = (uint8_t *) heap_caps_malloc(DisplayLen, MALLOC_CAP_SPIRAM);
```

SPI 外设无法直接对 PSRAM 做 DMA。因此每次 `esp_lcd_panel_io_tx_color()` 送整屏时，`spi_master` 都会走 `setup_dma_priv_buffer()`：**临时申请一块等大（15000 字节）的内部 DMA 缓冲，再把显存 memcpy 进去**，传完释放。

于是每一帧都要：

1. 从内部堆里凑出一块 15 KB 的连续 DMA 内存；
2. 做一次 15 KB memcpy。

对话过程中刷屏频率很高，而 WebSocket、音频编解码、AFE 又同时在抢内部内存。内部堆一旦碎片化或水位下降，这个每帧都发生的临时分配就会失败并返回 `ESP_ERR_NO_MEM`。

由于 `RLCD_Sendbuffera` 用 `ESP_ERROR_CHECK` 包住返回值，这个**本来可恢复的瞬时错误被直接升级成 `abort()`**，整机重启，对话中断。

## 修复方案

两处改动，都在 `custom_lcd_display.cc` 内：

**1. 显存改为内部 DMA 内存分配，失败才回退 PSRAM**

```cpp
DispBuffer = (uint8_t *) heap_caps_malloc(DisplayLen, MALLOC_CAP_DMA | MALLOC_CAP_INTERNAL);
if (DispBuffer == nullptr) {
    ESP_LOGW(TAG, "内部 DMA 显存分配失败(%d 字节)，回退到 PSRAM", (int)DisplayLen);
    DispBuffer = (uint8_t *) heap_caps_malloc(DisplayLen, MALLOC_CAP_SPIRAM);
}
```

显存本身可以直接 DMA 之后，`spi_master` 不再需要临时缓冲，**每帧的临时分配和 memcpy 都消失了**，刷屏路径变成确定性的。

取舍：代价是常驻占用 15 KB 内部内存。但这 15 KB 原本在每一帧刷屏时也照样要被临时占用，只是以"随时可能失败"的形式；把它换成启动时一次性分配，等于用同样的内存换来了确定性 + 少一次 15 KB memcpy。启动阶段内部内存最宽裕，此时分配几乎不会失败；万一失败也只是退回原有行为，不会让板子起不来。

**2. `RLCD_Sendbuffera` 不再用 `ESP_ERROR_CHECK`**

```cpp
esp_err_t err = esp_lcd_panel_io_tx_color(io_handle, -1, Data, len);
if (err != ESP_OK) {
    ESP_LOGW(TAG, "刷屏失败，跳过本帧: %s", esp_err_to_name(err));
}
```

刷屏失败是可恢复的瞬时状态，下一帧就会重画。丢一帧画面远好过 abort 重启整机。这一条是兜底：即使将来出现改动 1 没覆盖到的瞬时失败（比如走了 PSRAM 回退路径），设备也只是掉一帧，而不是重启。

## 实测

- 硬件：Waveshare ESP32-S3-RLCD-4.2 实板，连官方服务器。
- 修复前：长对话（AI 流式输出文本、屏幕高频刷新）下必崩，崩溃点与上面日志一致。
- 修复后：**连续 8 轮对话零崩溃**，日志中未出现 `刷屏失败，跳过本帧` 告警（说明改动 1 之后已经不再走临时缓冲路径，改动 2 的兜底也没被触发过），画面刷新正常。
- 测试环境：ESP-IDF v6.0.2。

## 影响范围

仅影响 `main/boards/waveshare/esp32-s3-rlcd-4.2/custom_lcd_display.cc`，即该板一款。不涉及公共代码、其他板型或任何 Kconfig / CMake 配置。
