### PR TITLE
xpowers: add generic PMU wrapper over I2cDevice

### DIFF
--- a/main/boards/common/i2c_device.cc
+++ b/main/boards/common/i2c_device.cc
@@ -1,6 +1,8 @@
 #include "i2c_device.h"
 
 #include <esp_log.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define TAG "I2cDevice"
 
@@ -23,6 +25,17 @@ I2cDevice::I2cDevice(i2c_master_bus_handle_t i2c_bus, uint8_t addr)
 void I2cDevice::WriteReg(uint8_t reg, uint8_t value) {
     uint8_t buffer[2] = {reg, value};
     ESP_ERROR_CHECK(i2c_master_transmit(i2c_device_, buffer, 2, 100));
+}
+
+void I2cDevice::WriteRegs(uint8_t reg, const uint8_t* buffer, size_t length) {
+    uint8_t* tx = (uint8_t*)malloc(length + 1);
+    if (tx == nullptr) {
+        return;
+    }
+    tx[0] = reg;
+    memcpy(tx + 1, buffer, length);
+    ESP_ERROR_CHECK(i2c_master_transmit(i2c_device_, tx, length + 1, 100));
+    free(tx);
 }
 
 uint8_t I2cDevice::ReadReg(uint8_t reg) {

--- a/main/boards/common/i2c_device.h
+++ b/main/boards/common/i2c_device.h
@@ -13,6 +13,7 @@ protected:
     uint8_t device_address_;
 
     void WriteReg(uint8_t reg, uint8_t value);
+    void WriteRegs(uint8_t reg, const uint8_t* buffer, size_t length);
     uint8_t ReadReg(uint8_t reg);
     void ReadRegs(uint8_t reg, uint8_t* buffer, size_t length);
     esp_err_t ResetBus(const char* reason);

--- a/main/boards/common/xpower.h
+++ b/main/boards/common/xpower.h
@@ -1,0 +1,105 @@
+#ifndef __XPOWERS_H__
+#define __XPOWERS_H__
+
+#include "i2c_device.h"
+
+#include <esp_log.h>
+
+// xpowerslib selects the chip at compile time via a macro: whichever XPOWERS_CHIP_*
+// is defined determines which class XPowersPMU is typedef'd to. The macro only takes
+// effect for the current translation unit, so it must be defined before including
+// this wrapper, e.g.:
+//   #define XPOWERS_CHIP_AXP2101
+//   #include "xpower.h"
+#if !defined(XPOWERS_CHIP_AXP192) && !defined(XPOWERS_CHIP_AXP202) && !defined(XPOWERS_CHIP_AXP2101)
+#error "Define XPOWERS_CHIP_AXP192/AXP202/AXP2101 before including xpower.h, \
+otherwise XPowersLib.h does not generate the XPowersPMU typedef"
+#endif
+
+#include "XPowersLib.h"
+
+// Generic XPowers power-management chip wrapper.
+//
+// How it hooks into I2cDevice (single bus handle):
+//   - The bus device handle is registered once by I2cDevice;
+//   - The XPowers library reuses that same handle through read/write callbacks
+//     instead of calling i2c_master_bus_add_device itself;
+//   - The actual I2C transfers go through the inherited ReadRegs/WriteRegs.
+//
+// The chip is determined by the XPowersPMU typedef, so the same code works for
+// AXP192 / AXP202 / AXP2101 alike. Subclasses (e.g. each board's Pmic) may still
+// call the inherited ReadReg/WriteReg directly for register-level access, or use
+// the public member pmu for xpowerslib's high-level API (rail voltages, charging
+// current, IRQs, etc.).
+class Xpowers : public I2cDevice {
+public:
+    Xpowers(i2c_master_bus_handle_t i2c_bus, uint8_t addr)
+        : I2cDevice(i2c_bus, addr), pmu() {
+        s_instances_[addr & 0x7F] = this;
+        if (!pmu.begin(addr, &Xpowers::ReadCallback, &Xpowers::WriteCallback)) {
+            ESP_LOGE("Xpowers", "XPowers PMU init failed at 0x%02x", addr);
+        }
+    }
+
+    // Entry point to xpowerslib's high-level API: pmu.enableDC3() / pmu.setChargerConstantCurr(...) / ...
+    XPowersPMU pmu;
+
+    // The convenience methods below behave the same on AXP192 / AXP202 / AXP2101, so
+    // they can be used directly; for chip-specific capabilities use pmu.<method>() instead.
+    bool IsCharging() {
+        return pmu.isCharging();
+    }
+
+    bool IsDischarging() {
+        return pmu.isDischarge();
+    }
+
+    int GetBatteryLevel() {
+        return pmu.getBatteryPercent();  // -1 if no battery connected
+    }
+
+    uint16_t GetBatteryVoltage() {
+        return pmu.getBattVoltage();
+    }
+
+    bool IsBatteryConnect() {
+        return pmu.isBatteryConnect();
+    }
+
+    float GetTemperature() {
+        return pmu.getTemperature();
+    }
+
+    void PowerOff() {
+        pmu.shutdown();
+    }
+
+private:
+    // The iic_fptr_t callbacks carry no `this`, so the instance is looked up in the
+    // static table by slave address.
+    static int ReadCallback(uint8_t devAddr, uint8_t regAddr, uint8_t* data, uint8_t len) {
+        Xpowers* self = Find(devAddr);
+        if (self == nullptr) {
+            return -1;
+        }
+        self->ReadRegs(regAddr, data, len);
+        return 0;
+    }
+
+    static int WriteCallback(uint8_t devAddr, uint8_t regAddr, uint8_t* data, uint8_t len) {
+        Xpowers* self = Find(devAddr);
+        if (self == nullptr) {
+            return -1;
+        }
+        self->WriteRegs(regAddr, data, len);
+        return 0;
+    }
+
+    static Xpowers* Find(uint8_t devAddr) {
+        return s_instances_[devAddr & 0x7F];
+    }
+
+    static inline Xpowers* s_instances_[128] = {};  // C++17 inline static member
+};
+
+#endif  // __XPOWERS_H__

--- a/main/idf_component.yml
+++ b/main/idf_component.yml
@@ -149,3 +149,5 @@ dependencies:
     - if: target in [esp32p4]
   m5stack/m5ioe1: ^1.0.8
   m5stack/m5pm1: ^1.0.5
+
+  cube32esp/xpowerslib: ^0.3.3


### PR DESCRIPTION
The xpowerslib library selects the concrete AXP192/202/2101 driver behind the `XPowersPMU` typedef at compile time. Instead of letting the library register its own handle on the I2C bus, route its register read/write through the shared `I2cDevice` handle using callback mode, so only one bus device is registered and the device is fully owned by `I2cDevice`. Add `WriteRegs` to `I2cDevice` to support multi-byte writes.