### PR TITLE
fix(build): reject mismatched board configuration

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -1112,7 +1112,14 @@ def _symbol_supports_target(symbol: str, target: str) -> bool:
             continue
         if in_symbol and stripped.startswith(("config ", "choice ", "endchoice", "menu ", "endmenu")):
             break
-        if in_symbol and "depends on" in stripped and target_flag in stripped:
+        if (
+            in_symbol
+            and "depends on" in stripped
+            and re.search(
+                rf"(?<![A-Za-z0-9_]){re.escape(target_flag)}(?![A-Za-z0-9_])",
+                stripped,
+            )
+        ):
             return True
     return False
 
@@ -1125,9 +1132,26 @@ def _resolve_board_config(
     variant_name: Optional[str] = None,
 ) -> str:
     """Resolve CONFIG_BOARD_TYPE_xxx for current board build."""
+    def validate_target(symbol: str) -> str:
+        if not _symbol_supports_target(symbol, target):
+            raise ValueError(
+                f"Board config {symbol} for {board_type!r} does not support "
+                f"target {target!r}"
+            )
+        return symbol
+
     explicit = _extract_board_config_from_sdkconfig_append(sdkconfig_append)
+    candidates = _find_board_config_candidates(board_type)
+    if not candidates:
+        raise ValueError(f"Cannot find board config symbol for {board_type}")
+
     if explicit and _board_config_symbol_exists(explicit):
-        return explicit
+        if explicit not in candidates:
+            raise ValueError(
+                f"Board config {explicit} does not select board directory "
+                f"{board_type!r}"
+            )
+        return validate_target(explicit)
     if explicit:
         print(
             f"[WARN] Explicit board config {explicit} does not exist in Kconfig; "
@@ -1135,11 +1159,8 @@ def _resolve_board_config(
             file=sys.stderr,
         )
 
-    candidates = _find_board_config_candidates(board_type)
-    if not candidates:
-        raise ValueError(f"Cannot find board config symbol for {board_type}")
     if len(candidates) == 1:
-        return candidates[0]
+        return validate_target(candidates[0])
 
     if variant_name:
         expected = "CONFIG_BOARD_TYPE_" + re.sub(
@@ -1149,11 +1170,11 @@ def _resolve_board_config(
         ).strip("_")
         by_variant = [candidate for candidate in candidates if candidate == expected]
         if len(by_variant) == 1:
-            return by_variant[0]
+            return validate_target(by_variant[0])
 
     by_target = [c for c in candidates if _symbol_supports_target(c, target)]
     if len(by_target) == 1:
-        return by_target[0]
+        return validate_target(by_target[0])
     if len(by_target) > 1:
         selected = by_target[0]
         print(
@@ -1161,32 +1182,12 @@ def _resolve_board_config(
             f"target-matched candidates={by_target}, selecting first: {selected}",
             file=sys.stderr,
         )
-        return selected
+        return validate_target(selected)
 
-    target_u = target.upper()
-    target_short = target_u.replace("ESP32", "")
-    by_name = [
-        c for c in candidates
-        if target_u in c or f"_{target_short}" in c
-    ]
-    if len(by_name) == 1:
-        return by_name[0]
-    if len(by_name) > 1:
-        selected = by_name[0]
-        print(
-            f"[WARN] Ambiguous board config for {board_type} (target={target}), "
-            f"name-matched candidates={by_name}, selecting first: {selected}",
-            file=sys.stderr,
-        )
-        return selected
-
-    selected = candidates[0]
-    print(
-        f"[WARN] Ambiguous board config for {board_type} (target={target}), "
-        f"candidates={candidates}, selecting first: {selected}",
-        file=sys.stderr,
+    raise ValueError(
+        f"No board config for {board_type!r} supports target {target!r}; "
+        f"candidates: {candidates}"
     )
-    return selected
 
 
 # Kconfig "select" entries are not automatically applied when we simply append
@@ -1505,7 +1506,9 @@ def build_board(
         )
 
         user_options: list[str] = []
-        validation_symbols: list[tuple[list[str], str]] = []
+        validation_symbols: list[tuple[list[str], str]] = [
+            ([board_type_config], "board selection"),
+        ]
         build_option_sdkconfig: list[str] = []
         selected_language = None
         selected_wake_word = None

--- a/scripts/tests/test_build.py
+++ b/scripts/tests/test_build.py
@@ -337,6 +337,110 @@ class BoardSelectionTests(unittest.TestCase):
             "Alientek ATK-DNESP32S3 Development Board (正点原子)",
         )
 
+    def test_board_target_matching_uses_complete_kconfig_symbols(self):
+        self.assertTrue(
+            build._symbol_supports_target(
+                "CONFIG_BOARD_TYPE_BREAD_COMPACT_WIFI",
+                "esp32s3",
+            )
+        )
+        self.assertFalse(
+            build._symbol_supports_target(
+                "CONFIG_BOARD_TYPE_BREAD_COMPACT_WIFI",
+                "esp32",
+            )
+        )
+        self.assertTrue(
+            build._symbol_supports_target(
+                "CONFIG_BOARD_TYPE_ESP32_S31_FUNCTION_COREBOARD_1",
+                "esp32s31",
+            )
+        )
+        self.assertFalse(
+            build._symbol_supports_target(
+                "CONFIG_BOARD_TYPE_ESP32_S31_FUNCTION_COREBOARD_1",
+                "esp32s3",
+            )
+        )
+
+    def test_explicit_board_config_rejects_incompatible_target(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not support target 'esp32c3'",
+        ):
+            build._resolve_board_config(
+                "bread-compact-wifi",
+                "esp32c3",
+                ["CONFIG_BOARD_TYPE_BREAD_COMPACT_WIFI=y"],
+            )
+
+    def test_explicit_board_config_rejects_different_board_directory(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not select board directory 'bread-compact-wifi'",
+        ):
+            build._resolve_board_config(
+                "bread-compact-wifi",
+                "esp32s3",
+                ["CONFIG_BOARD_TYPE_M5STACK_CORE_S3=y"],
+            )
+
+    def test_inferred_board_config_rejects_incompatible_target(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            "does not support target 'esp32c3'",
+        ):
+            build._resolve_board_config(
+                "bread-compact-wifi",
+                "esp32c3",
+                [],
+            )
+
+    def test_rejected_board_selection_stops_before_build(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            board_dir = Path(temp_dir) / "test-board"
+            board_dir.mkdir()
+            (board_dir / "config.json").write_text(
+                json.dumps({
+                    "target": "esp32s3",
+                    "type": "test-board",
+                    "builds": [{"name": "test-board"}],
+                }),
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.object(build, "_BOARDS_DIR", Path(temp_dir)),
+                mock.patch.object(build, "get_project_version", return_value="1.0.0"),
+                mock.patch.object(
+                    build,
+                    "_resolve_board_config",
+                    return_value="CONFIG_BOARD_TYPE_TEST",
+                ),
+                mock.patch.object(build, "_build_option_definitions", return_value=[]),
+                mock.patch.object(build, "_prepare_target"),
+                mock.patch.object(build, "_configure_build"),
+                mock.patch.object(
+                    build,
+                    "_validate_configured_symbols",
+                    side_effect=ValueError("Kconfig rejected board selection"),
+                ) as validate_symbols,
+                mock.patch.object(build, "_run_idf") as run_idf,
+                contextlib.redirect_stdout(io.StringIO()),
+            ):
+                with self.assertRaisesRegex(ValueError, "Kconfig rejected"):
+                    build.build_board(
+                        "test-board",
+                        name_filter="test-board",
+                        idf_version=(6, 0, 2),
+                    )
+
+            validate_symbols.assert_called_once_with(
+                ["CONFIG_BOARD_TYPE_TEST"],
+                "board selection",
+            )
+            run_idf.assert_not_called()
+
     def test_variant_name_disambiguates_shared_board_directory(self):
         board = "lilygo/t-cameraplus-s3"
         self.assertEqual(


### PR DESCRIPTION
## Summary

- match `IDF_TARGET_*` as complete Kconfig symbols instead of prefixes
- reject explicit board symbols that belong to another board directory or do not support `config.json.target`
- stop ambiguous resolution when no candidate supports the requested target
- verify after `reconfigure` that Kconfig retained the intended board selection
- add regression coverage for ESP32/ESP32-S3/ESP32-S31 prefix collisions, directory mismatches, inferred mismatches, and pre-build rejection

Fixes #2239

## Testing

- `python -m py_compile scripts/build.py scripts/tests/test_build.py`
- `python -m unittest scripts.tests.test_build.VersionTests scripts.tests.test_build.BoardSelectionTests -v` (21 passed)
- `python scripts/build.py --list-boards` (passed for the current 175-variant matrix)
- `python -m unittest discover -s scripts/tests -v` (72 executed; 5 pre-existing Windows `TemporaryDirectory` cleanup errors remain because those tests try to delete their current working directory)

ESP-IDF is not installed in this Windows environment, so no firmware build or physical hardware smoke test was performed.