### PR TITLE
fix(websocket): guard transport field before strcmp in server hello

### DIFF
--- a/main/protocols/websocket_protocol.cc
+++ b/main/protocols/websocket_protocol.cc
@@ -224,7 +224,11 @@ std::string WebsocketProtocol::GetHelloMessage() {
 
 void WebsocketProtocol::ParseServerHello(const cJSON* root) {
     auto transport = cJSON_GetObjectItem(root, "transport");
-    if (transport == nullptr || strcmp(transport->valuestring, "websocket") != 0) {
+    if (!cJSON_IsString(transport)) {
+        ESP_LOGE(TAG, "Missing or non-string transport in server hello");
+        return;
+    }
+    if (strcmp(transport->valuestring, "websocket") != 0) {
         ESP_LOGE(TAG, "Unsupported transport: %s", transport->valuestring);
         return;
     }


### PR DESCRIPTION
`WebsocketProtocol::ParseServerHello()` passed `transport->valuestring` straight to
`strcmp()` without checking `cJSON_IsString()` first. A server hello carrying a
non-string transport, for example `{"type":"hello","transport":1}`, leaves
`valuestring` NULL, so `strcmp()` read from address 0 and the device panicked.

`MqttProtocol::ParseServerHello()` already guards this field the same way, so only
the WebSocket transport is affected. The check is split into two branches so the
existing `Unsupported transport: %s` log keeps reporting the real value instead of
losing it.

### Testing

Not built or run: no ESP-IDF toolchain is available here, so this is neither
compiled nor verified on hardware. The change only adds a type check in front of
an existing `strcmp()`.
