### PR TITLE
fix(ota): parse versions without throwing

### DIFF
--- a/main/audio/audio_debugger.cc
+++ b/main/audio/audio_debugger.cc
@@ -4,10 +4,13 @@
 
 #if CONFIG_USE_AUDIO_DEBUGGER
 #include <arpa/inet.h>
+#include <charconv>
+#include <cstdint>
 #include <cstring>
 #include <errno.h>
 #include <esp_log.h>
 #include <string>
+#include <system_error>
 #include <unistd.h>
 #endif
 
@@ -22,14 +25,25 @@ AudioDebugger::AudioDebugger() {
 
         if (colon_pos != std::string::npos) {
             std::string ip = server_addr.substr(0, colon_pos);
-            int port = std::stoi(server_addr.substr(colon_pos + 1));
+            std::string port_str = server_addr.substr(colon_pos + 1);
+            int port = 0;
+            auto [ptr, ec] =
+                std::from_chars(port_str.data(), port_str.data() + port_str.size(), port);
 
-            memset(&udp_server_addr_, 0, sizeof(udp_server_addr_));
-            udp_server_addr_.sin_family = AF_INET;
-            udp_server_addr_.sin_port = htons(port);
-            inet_pton(AF_INET, ip.c_str(), &udp_server_addr_.sin_addr);
+            if (ec == std::errc() && ptr == port_str.data() + port_str.size() && port > 0 &&
+                port <= UINT16_MAX) {
+                memset(&udp_server_addr_, 0, sizeof(udp_server_addr_));
+                udp_server_addr_.sin_family = AF_INET;
+                udp_server_addr_.sin_port = htons(port);
+                inet_pton(AF_INET, ip.c_str(), &udp_server_addr_.sin_addr);
 
-            ESP_LOGI(TAG, "Initialized server address: %s", CONFIG_AUDIO_DEBUG_UDP_SERVER);
+                ESP_LOGI(TAG, "Initialized server address: %s", CONFIG_AUDIO_DEBUG_UDP_SERVER);
+            } else {
+                ESP_LOGW(TAG, "Invalid server address: %s, should be IP:PORT",
+                         CONFIG_AUDIO_DEBUG_UDP_SERVER);
+                close(udp_sockfd_);
+                udp_sockfd_ = -1;
+            }
         } else {
             ESP_LOGW(TAG, "Invalid server address: %s, should be IP:PORT", CONFIG_AUDIO_DEBUG_UDP_SERVER);
             close(udp_sockfd_);

--- a/main/ota.cc
+++ b/main/ota.cc
@@ -17,10 +17,12 @@
 #include <esp_hmac.h>
 #endif
 
-#include <cstring>
-#include <vector>
-#include <sstream>
 #include <algorithm>
+#include <charconv>
+#include <cstring>
+#include <expected>
+#include <system_error>
+#include <vector>
 
 #define TAG "Ota"
 
@@ -400,31 +402,58 @@ bool Ota::StartUpgrade(std::function<void(int progress, size_t speed)> callback)
 }
 
 
-std::vector<int> Ota::ParseVersion(const std::string& version) {
-    std::vector<int> versionNumbers;
-    std::stringstream ss(version);
-    std::string segment;
-    
-    while (std::getline(ss, segment, '.')) {
-        versionNumbers.push_back(std::stoi(segment));
+// Versions are compared as dot-separated decimal numbers. Parsing must never throw: exceptions are
+// disabled in this project, so a malformed string from the server would otherwise terminate the
+// firmware instead of being reported as an error.
+std::expected<std::vector<int>, std::string> Ota::ParseVersion(const std::string& version) {
+    std::vector<int> version_numbers;
+    size_t start = 0;
+
+    while (true) {
+        size_t end = version.find('.', start);
+        std::string segment =
+            version.substr(start, end == std::string::npos ? std::string::npos : end - start);
+
+        int value = 0;
+        auto [ptr, ec] = std::from_chars(segment.data(), segment.data() + segment.size(), value);
+        if (segment.empty() || ec != std::errc() || ptr != segment.data() + segment.size()) {
+            return std::unexpected("invalid version segment \"" + segment + "\"");
+        }
+        version_numbers.push_back(value);
+
+        if (end == std::string::npos) {
+            return version_numbers;
+        }
+        start = end + 1;
     }
-    
-    return versionNumbers;
 }
 
 bool Ota::IsNewVersionAvailable(const std::string& currentVersion, const std::string& newVersion) {
-    std::vector<int> current = ParseVersion(currentVersion);
-    std::vector<int> newer = ParseVersion(newVersion);
-    
-    for (size_t i = 0; i < std::min(current.size(), newer.size()); ++i) {
-        if (newer[i] > current[i]) {
+    auto current = ParseVersion(currentVersion);
+    if (!current) {
+        ESP_LOGW(TAG, "Cannot parse current version \"%s\": %s", currentVersion.c_str(),
+                 current.error().c_str());
+        return false;
+    }
+
+    auto newer = ParseVersion(newVersion);
+    if (!newer) {
+        // Never report an update we cannot compare, otherwise a malformed version string would
+        // trigger a firmware downgrade or an endless upgrade loop.
+        ESP_LOGW(TAG, "Ignoring firmware version \"%s\": %s", newVersion.c_str(),
+                 newer.error().c_str());
+        return false;
+    }
+
+    for (size_t i = 0; i < std::min(current->size(), newer->size()); ++i) {
+        if ((*newer)[i] > (*current)[i]) {
             return true;
-        } else if (newer[i] < current[i]) {
+        } else if ((*newer)[i] < (*current)[i]) {
             return false;
         }
     }
-    
-    return newer.size() > current.size();
+
+    return newer->size() > current->size();
 }
 
 std::string Ota::GetActivationPayload() {

--- a/main/ota.h
+++ b/main/ota.h
@@ -1,6 +1,7 @@
 #ifndef _OTA_H
 #define _OTA_H
 
+#include <expected>
 #include <functional>
 #include <string>
 #include <vector>
@@ -51,7 +52,7 @@ private:
     int activation_timeout_ms_ = 30000;
 
     std::function<void(int progress, size_t speed)> upgrade_callback_;
-    std::vector<int> ParseVersion(const std::string& version);
+    std::expected<std::vector<int>, std::string> ParseVersion(const std::string& version);
     bool IsNewVersionAvailable(const std::string& currentVersion, const std::string& newVersion);
     std::string GetActivationPayload();
     std::unique_ptr<Http> SetupHttp();

--- a/main/protocols/mqtt_protocol.cc
+++ b/main/protocols/mqtt_protocol.cc
@@ -6,7 +6,9 @@
 #include <esp_log.h>
 #include <arpa/inet.h>
 #include <netdb.h>
+#include <charconv>
 #include <cstring>
+#include <system_error>
 #include "assets/lang_config.h"
 
 #define TAG "MQTT"
@@ -151,7 +153,17 @@ bool MqttProtocol::StartMqttClient(bool report_error) {
     size_t pos = endpoint.find(':');
     if (pos != std::string::npos) {
         broker_address = endpoint.substr(0, pos);
-        broker_port = std::stoi(endpoint.substr(pos + 1));
+        auto port_str = endpoint.substr(pos + 1);
+        int parsed_port = 0;
+        auto [ptr, ec] =
+            std::from_chars(port_str.data(), port_str.data() + port_str.size(), parsed_port);
+        if (ec == std::errc() && ptr == port_str.data() + port_str.size() && parsed_port > 0 &&
+            parsed_port <= UINT16_MAX) {
+            broker_port = parsed_port;
+        } else {
+            ESP_LOGW(TAG, "Invalid port in MQTT endpoint \"%s\", using %d", endpoint.c_str(),
+                     broker_port);
+        }
     } else {
         broker_address = endpoint;
     }


### PR DESCRIPTION
C++ exceptions are disabled (`CONFIG_COMPILER_CXX_EXCEPTIONS=n`), so `std::stoi()`
never reports an error: it calls `std::terminate()` and aborts the firmware. Three
call sites survived the recent exceptions removal, and two of them read remote
input:

- `Ota::ParseVersion()` parses the version string reported by the OTA server. It
  runs on the boot path (`ActivationTask()` -> `CheckNewVersion()`), so a value
  such as `2.0.0-rc1`, `v2.5.0`, `""` or `99999999999` terminated the device on
  every boot, which turns into a reboot loop.
- `MqttProtocol::StartMqttClient()` parses the port out of the endpoint that the
  OTA config pushes into NVS.
- `AudioDebugger` parses a port from `CONFIG_AUDIO_DEBUG_UDP_SERVER`.

`Ota::ParseVersion()` now parses with `std::from_chars()` and returns
`std::expected<std::vector<int>, std::string>`, matching the error handling style
introduced when exceptions were removed. An unparsable version is logged and
ignored rather than reported as an update; the `force` flag still overrides. Both
port parsers fall back to their previous default and log a warning.

One behaviour change worth calling out: a version with trailing garbage (`"2.4.2 "`)
used to parse as 2.4.2 and now counts as unparsable, so such an update is skipped
with a warning instead of applied. I took the strict reading because the goal is to
never abort on server input; if you would rather tolerate surrounding whitespace I
can trim before parsing.

### Testing

- `python -m unittest discover -s scripts/tests -v`: 81 tests, same 5 pre-existing
  Windows tempdir errors as on `main` (unrelated to this change).
- Touched files are clang-format clean for the added code; pre-existing drift
  elsewhere in `ota.cc`, `ota.h` and `audio_debugger.cc` was left alone.

Not built or run on hardware: no ESP-IDF toolchain is available here.
