### PR TITLE
fix(esp-vocat): stabilize PCB version detection across soft resets

### DIFF
--- a/main/boards/espressif/esp-vocat/esp_vocat.cc
+++ b/main/boards/espressif/esp-vocat/esp_vocat.cc
@@ -9,6 +9,7 @@
 #include "wifi_board.h"
 
 #include <esp_log.h>
+#include <esp_system.h>
 #include <esp_timer.h>
 #include <cinttypes>
 #include "esp_idf_version.h"
@@ -278,6 +279,13 @@ gpio_num_t QSPI_PIN_NUM_LCD_RST = QSPI_PIN_NUM_LCD_RST_1;
 gpio_num_t TOUCH_PAD2 = TOUCH_PAD2_1;
 gpio_num_t UART1_TX = UART1_TX_1;
 gpio_num_t UART1_RX = UART1_RX_1;
+
+// The PCB version is cached in RTC noinit memory so it survives every reset
+// except a real power cycle. Probing after a soft reset is unreliable: the
+// codec supply rail keeps residual charge (see DetectPcbVersion).
+static constexpr uint32_t kPcbVersionMagic = 0x31434256;  // "VBC1"
+static RTC_NOINIT_ATTR uint32_t s_pcb_version_magic;
+static RTC_NOINIT_ATTR uint8_t s_pcb_version_cached;
 
 class EspVocat;
 
@@ -651,24 +659,67 @@ private:
         ESP_ERROR_CHECK(temperature_sensor_enable(temp_sensor));
     }
     uint8_t DetectPcbVersion() {
+        // Pre-set the output latch before switching the pin to output mode:
+        // after an external reset the latch defaults to 0, and driving 0 on
+        // GPIO48 for even a moment cuts the codec rail on V1.2, after which
+        // the first touch/fuel-gauge read aborts and the device reboots. On a
+        // power-on reset we deliberately start at 0 so the probe below sees an
+        // unpowered (and therefore silent) V1.2 codec.
+        const esp_reset_reason_t reset_reason = esp_reset_reason();
+        gpio_set_level(CORDEC_POWER_CTRL, reset_reason != ESP_RST_POWERON ? 1 : 0);
         gpio_config_t gpio_conf = {.pin_bit_mask = (1ULL << CORDEC_POWER_CTRL),
                                    .mode = GPIO_MODE_OUTPUT,
                                    .pull_up_en = GPIO_PULLUP_DISABLE,
                                    .pull_down_en = GPIO_PULLDOWN_DISABLE,
                                    .intr_type = GPIO_INTR_DISABLE};
         ESP_ERROR_CHECK(gpio_config(&gpio_conf));
+
+        // After any reset other than a real power cycle the codec rail on
+        // V1.2 keeps residual charge, so the "GPIO48 low" probe below sees a
+        // false ACK from ES8311 and the board is misdetected as V1.0. GPIO48
+        // then stays low, the codec loses power and mic/speaker die while the
+        // screen keeps working; the unpowered chips also clamp the shared I2C
+        // bus and the first fuel-gauge/touch read aborts, causing a reboot
+        // loop (issue #1202). Only probe on a power-on reset; every other
+        // reset reuses the cached result, and the GPIO output latch (kept
+        // across soft resets) keeps the codec powered in the meantime.
+        if (reset_reason != ESP_RST_POWERON && s_pcb_version_magic == kPcbVersionMagic &&
+            s_pcb_version_cached <= 1) {
+            if (s_pcb_version_cached == 1) {
+                // V1.2: the codec rail is powered from GPIO48; make sure it stays
+                // on and wait for the touch controller to answer, since reads
+                // against a still-powering-up chip abort the whole system.
+                ESP_ERROR_CHECK(gpio_set_level(CORDEC_POWER_CTRL, 1));
+                for (int i = 0; i < 10; i++) {
+                    if (i2c_master_probe(i2c_bus_, 0x15, 50) == ESP_OK) {
+                        break;
+                    }
+                    vTaskDelay(pdMS_TO_TICKS(200));
+                }
+            }
+            ESP_LOGI(TAG, "PCB version %s (cached, reset reason %d)",
+                     s_pcb_version_cached ? "V1.2" : "V1.0", static_cast<int>(reset_reason));
+            return s_pcb_version_cached;
+        }
+
         ESP_ERROR_CHECK(gpio_set_level(CORDEC_POWER_CTRL, 0));
-        vTaskDelay(pdMS_TO_TICKS(50));
+        vTaskDelay(pdMS_TO_TICKS(100));
 
         bool codec_alive = (i2c_master_probe(i2c_bus_, 0x18, 100) == ESP_OK);
         uint8_t pcb_version = 0;
         if (codec_alive) {
+            // Codec answers while GPIO48 is low: its supply is not gated by
+            // GPIO48, so this is a V1.0 board.
             ESP_LOGI(TAG, "PCB version V1.0");
-            pcb_version = 0;
         } else {
             ESP_ERROR_CHECK(gpio_set_level(CORDEC_POWER_CTRL, 1));
-            vTaskDelay(pdMS_TO_TICKS(50));
-            codec_alive = (i2c_master_probe(i2c_bus_, 0x18, 100) == ESP_OK);
+            // V1.2: wait for the SY8088 rail and the ES8311 to come up. The
+            // previous 50 ms delay was too short right after a cold boot and
+            // made the probe fail, falling back to the wrong V1.0 pins.
+            for (int i = 0; i < 10 && !codec_alive; i++) {
+                vTaskDelay(pdMS_TO_TICKS(200));
+                codec_alive = (i2c_master_probe(i2c_bus_, 0x18, 100) == ESP_OK);
+            }
             if (codec_alive) {
                 ESP_LOGI(TAG, "PCB version V1.2");
                 pcb_version = 1;
@@ -679,9 +730,17 @@ private:
                 UART1_TX = UART1_TX_2;
                 UART1_RX = UART1_RX_2;
             } else {
+                // Both probes failed: leave GPIO48 high as a safe fallback. On
+                // V1.0 the pin is unused; on V1.2 it keeps the codec powered so
+                // an unpowered codec cannot clamp the shared I2C bus through
+                // its ESD diodes and crash the system. Nothing is cached in
+                // this branch, so the next boot probes again.
                 ESP_LOGE(TAG, "PCB version detection error");
+                return 0;
             }
         }
+        s_pcb_version_magic = kPcbVersionMagic;
+        s_pcb_version_cached = pcb_version;
         return pcb_version;
     }
 

--- a/main/boards/espressif/esp-vocat/esp_vocat.cc
+++ b/main/boards/espressif/esp-vocat/esp_vocat.cc
@@ -658,6 +658,19 @@ private:
         ESP_ERROR_CHECK(temperature_sensor_install(&temp_sensor_config, &temp_sensor));
         ESP_ERROR_CHECK(temperature_sensor_enable(temp_sensor));
     }
+    // Switch the board-level pin variables from their V1.0 defaults to the
+    // V1.2 layout. Must run on every boot that resolves to V1.2, including
+    // the cached path: these globals start at the _1 values and GetAudioCodec()
+    // reads them long after this function has returned.
+    static void ApplyV12Pins() {
+        AUDIO_I2S_GPIO_DIN = AUDIO_I2S_GPIO_DIN_2;
+        AUDIO_CODEC_PA_PIN = AUDIO_CODEC_PA_PIN_2;
+        QSPI_PIN_NUM_LCD_RST = QSPI_PIN_NUM_LCD_RST_2;
+        TOUCH_PAD2 = TOUCH_PAD2_2;
+        UART1_TX = UART1_TX_2;
+        UART1_RX = UART1_RX_2;
+    }
+
     uint8_t DetectPcbVersion() {
         // Pre-set the output latch before switching the pin to output mode:
         // after an external reset the latch defaults to 0, and driving 0 on
@@ -696,6 +709,7 @@ private:
                     }
                     vTaskDelay(pdMS_TO_TICKS(200));
                 }
+                ApplyV12Pins();
             }
             ESP_LOGI(TAG, "PCB version %s (cached, reset reason %d)",
                      s_pcb_version_cached ? "V1.2" : "V1.0", static_cast<int>(reset_reason));
@@ -723,12 +737,7 @@ private:
             if (codec_alive) {
                 ESP_LOGI(TAG, "PCB version V1.2");
                 pcb_version = 1;
-                AUDIO_I2S_GPIO_DIN = AUDIO_I2S_GPIO_DIN_2;
-                AUDIO_CODEC_PA_PIN = AUDIO_CODEC_PA_PIN_2;
-                QSPI_PIN_NUM_LCD_RST = QSPI_PIN_NUM_LCD_RST_2;
-                TOUCH_PAD2 = TOUCH_PAD2_2;
-                UART1_TX = UART1_TX_2;
-                UART1_RX = UART1_RX_2;
+                ApplyV12Pins();
             } else {
                 // Both probes failed: leave GPIO48 high as a safe fallback. On
                 // V1.0 the pin is unused; on V1.2 it keeps the codec powered so


### PR DESCRIPTION
Fixes the mic/speaker failure reported in #1202 on ESP-VoCat V1.2 boards.

## Problem

After any reset other than a real power cycle (WiFi provisioning restart, OTA
reboot, panic reboot), `DetectPcbVersion()` misdetects a V1.2 board as V1.0:

- On V1.2 the codec rail (ES8311 + ES7210 + touch controller) is gated by
  GPIO48 through a SY8088 DCDC. After a soft reset the rail keeps residual
  charge, so the "GPIO48 low" probe still gets an ACK from ES8311 and the
  board is read as V1.0.
- GPIO48 then stays low: the codec loses power, mic and speaker die while the
  screen keeps working (its QSPI pins are identical on both revisions).
- The unpowered chips clamp the shared I2C bus through their ESD diodes, so
  the periodic fuel-gauge read (`I2cDevice::ReadRegs`, guarded by
  `ESP_ERROR_CHECK`) aborts and the device enters a reboot loop. Logs show
  `PCB version detection error` / `PCB version V1.0` alternating, with the
  crash backtrace in `i2c_device.cc:48`.

Once misdetected, only a full power cycle recovers the board, which matches
the reports in #1202.

## Fix

1. Cache the detected version in RTC noinit memory (magic-guarded) and only
   probe on `ESP_RST_POWERON`, when the rail is guaranteed to be discharged
   and the probe is trustworthy. Every other reset reason reuses the cache
   and applies the V1.2 pin switch (`ApplyV12Pins()`).
2. Drive GPIO48 high *before* switching the pin to output mode: an external
   reset clears the output latch to 0, and driving 0 for even a moment cuts
   the codec rail on V1.2. The cached V1.2 path also waits for the touch
   controller (0x15) to answer again before continuing.
3. Give the V1.2 rail up to 2 s to come up before the second probe (the
   previous 50 ms was too short right after a cold boot and made detection
   fall back to the wrong V1.0 pins). On detection failure, leave GPIO48 high
   (harmless on V1.0, keeps the codec powered on V1.2 so a dying codec cannot
   clamp the bus) and skip caching so the next boot probes again.

Known limitation: the very first boot after flashing new firmware has no
valid cache, so one external-reset boot may still misdetect until the device
is power-cycled once. Soft resets after that are always served from the
cache.

### Testing

Built with ESP-IDF v6.1 and verified on hardware — an ESP-VoCat board whose
codec/touch rail is GPIO48-gated (V1.2 behaviour):

- Before the fix, on stock v2.5.0: provisioning restart reliably killed mic
  and speaker, with `PCB version V1.0`/`detection error` alternating across
  abort-reboot cycles (5+ crashes per cold boot observed).
- After the fix, verified with serial logs **and on-device voice tests**:
  - cold boot (POWERON): `PCB version V1.2` detected via the probe path,
    V1.2 pins applied, mic and speaker work;
  - soft/external resets: `PCB version V1.2 (cached, ...)` served in ~240 ms
    with the V1.2 pins applied. Note: the cached path initially omitted the
    pin switch (boards booted with V1.0 pins and audio stayed dead); an
    on-device wake-word test caught it and 2b183ab fixes it — logging `Set
    input enable to true` alone is not sufficient evidence because the
    codec's I2C pins are identical on both revisions;
  - full round trip verified: "你好喵伴" wake word detected (`Wake word
    detected: 你好喵伴`), server ASR transcript returned (`>> 你好喵伴`),
    TTS reply played (`listening -> speaking`), second conversation turn
    recognized;
  - the detection-failure path keeps GPIO48 high and retries on the next
    boot instead of falling back silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)